### PR TITLE
[ci] Use macOS 13 Ventura build agents

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -30,7 +30,7 @@ variables:
   1ESWindowsPool: AzurePipelines-EO
   1ESWindowsImage: AzurePipelinesWindows2022compliant
   1ESMacPool: Azure Pipelines
-  1ESMacImage: internal-macos-11
+  1ESMacImage: macOS-13
   DisablePipelineConfigDetector: true
 
 jobs:


### PR DESCRIPTION
The macOS-11 Big Sur image was retired June 28, 2024.