### PR TITLE
[generator] Fix potential callback naming conflict.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -66,13 +66,13 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_OnAnimationEnd_I;
+	static Delegate cb_OnAnimationEnd_OnAnimationEnd_I_Z;
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IHandler ()
 	{
-		if (cb_OnAnimationEnd_I == null)
-			cb_OnAnimationEnd_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
-		return cb_OnAnimationEnd_I;
+		if (cb_OnAnimationEnd_OnAnimationEnd_I_Z == null)
+			cb_OnAnimationEnd_OnAnimationEnd_I_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
+		return cb_OnAnimationEnd_OnAnimationEnd_I_Z;
 	}
 
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
@@ -92,13 +92,13 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 		return JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_OnAnimationEnd_I, __args);
 	}
 
-	static Delegate cb_OnAnimationEnd_II;
+	static Delegate cb_OnAnimationEnd_OnAnimationEnd_II_Z;
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IIHandler ()
 	{
-		if (cb_OnAnimationEnd_II == null)
-			cb_OnAnimationEnd_II = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
-		return cb_OnAnimationEnd_II;
+		if (cb_OnAnimationEnd_OnAnimationEnd_II_Z == null)
+			cb_OnAnimationEnd_OnAnimationEnd_II_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
+		return cb_OnAnimationEnd_OnAnimationEnd_II_Z;
 	}
 
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -62,13 +62,13 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_DoSomething;
+	static Delegate cb_DoSomething_DoSomething_V;
 #pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
-		if (cb_DoSomething == null)
-			cb_DoSomething = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
-		return cb_DoSomething;
+		if (cb_DoSomething_DoSomething_V == null)
+			cb_DoSomething_DoSomething_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
+		return cb_DoSomething_DoSomething_V;
 	}
 
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -49,13 +49,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate? cb_get_Count;
+	static Delegate? cb_get_Count_get_Count_I;
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count;
+		if (cb_get_Count_get_Count_I == null)
+			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
+		return cb_get_Count_get_Count_I;
 	}
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
@@ -65,13 +65,13 @@ public partial class MyClass {
 	}
 #pragma warning restore 0169
 
-	static Delegate? cb_set_Count_I;
+	static Delegate? cb_set_Count_set_Count_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_I;
+		if (cb_set_Count_set_Count_I_V == null)
+			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
+		return cb_set_Count_set_Count_I_V;
 	}
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -105,13 +105,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate? cb_get_Key;
+	static Delegate? cb_get_Key_get_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key;
+		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
+			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
+		return cb_get_Key_get_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
@@ -121,13 +121,13 @@ public partial class MyClass {
 	}
 #pragma warning restore 0169
 
-	static Delegate? cb_set_Key_Ljava_lang_String_;
+	static Delegate? cb_set_Key_set_Key_Ljava_lang_String__V;
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_Ljava_lang_String_;
+		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
+			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
+		return cb_set_Key_set_Key_Ljava_lang_String__V;
 	}
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
@@ -188,13 +188,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate? cb_get_AbstractCount;
+	static Delegate? cb_get_AbstractCount_get_AbstractCount_I;
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount;
+		if (cb_get_AbstractCount_get_AbstractCount_I == null)
+			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
+		return cb_get_AbstractCount_get_AbstractCount_I;
 	}
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
@@ -204,13 +204,13 @@ public partial class MyClass {
 	}
 #pragma warning restore 0169
 
-	static Delegate? cb_set_AbstractCount_I;
+	static Delegate? cb_set_AbstractCount_set_AbstractCount_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_I;
+		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
+			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
+		return cb_set_AbstractCount_set_AbstractCount_I_V;
 	}
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -230,13 +230,13 @@ public partial class MyClass {
 		set; 
 	}
 
-	static Delegate? cb_GetCountForKey_Ljava_lang_String_;
+	static Delegate? cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_Ljava_lang_String_;
+		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
+			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 	}
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
@@ -264,13 +264,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate? cb_Key;
+	static Delegate? cb_Key_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key;
+		if (cb_Key_Key_Ljava_lang_String_ == null)
+			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
+		return cb_Key_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
@@ -303,13 +303,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate? cb_AbstractMethod;
+	static Delegate? cb_AbstractMethod_AbstractMethod_V;
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod;
+		if (cb_AbstractMethod_AbstractMethod_V == null)
+			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
+		return cb_AbstractMethod_AbstractMethod_V;
 	}
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -130,13 +130,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate? cb_get_Count;
+	static Delegate? cb_get_Count_get_Count_I;
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count;
+		if (cb_get_Count_get_Count_I == null)
+			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
+		return cb_get_Count_get_Count_I;
 	}
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
@@ -146,13 +146,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 #pragma warning restore 0169
 
-	static Delegate? cb_set_Count_I;
+	static Delegate? cb_set_Count_set_Count_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_I;
+		if (cb_set_Count_set_Count_I_V == null)
+			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
+		return cb_set_Count_set_Count_I_V;
 	}
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -179,13 +179,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		}
 	}
 
-	static Delegate? cb_get_Key;
+	static Delegate? cb_get_Key_get_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key;
+		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
+			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
+		return cb_get_Key_get_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
@@ -195,13 +195,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 #pragma warning restore 0169
 
-	static Delegate? cb_set_Key_Ljava_lang_String_;
+	static Delegate? cb_set_Key_set_Key_Ljava_lang_String__V;
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_Ljava_lang_String_;
+		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
+			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
+		return cb_set_Key_set_Key_Ljava_lang_String__V;
 	}
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
@@ -231,13 +231,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		}
 	}
 
-	static Delegate? cb_get_AbstractCount;
+	static Delegate? cb_get_AbstractCount_get_AbstractCount_I;
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount;
+		if (cb_get_AbstractCount_get_AbstractCount_I == null)
+			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
+		return cb_get_AbstractCount_get_AbstractCount_I;
 	}
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
@@ -247,13 +247,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 #pragma warning restore 0169
 
-	static Delegate? cb_set_AbstractCount_I;
+	static Delegate? cb_set_AbstractCount_set_AbstractCount_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_I;
+		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
+			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
+		return cb_set_AbstractCount_set_AbstractCount_I_V;
 	}
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -280,13 +280,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		}
 	}
 
-	static Delegate? cb_GetCountForKey_Ljava_lang_String_;
+	static Delegate? cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_Ljava_lang_String_;
+		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
+			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 	}
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
@@ -311,13 +311,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		return __ret;
 	}
 
-	static Delegate? cb_Key;
+	static Delegate? cb_Key_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key;
+		if (cb_Key_Key_Ljava_lang_String_ == null)
+			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
+		return cb_Key_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
@@ -335,13 +335,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_Key), JniHandleOwnership.TransferLocalRef);
 	}
 
-	static Delegate? cb_AbstractMethod;
+	static Delegate? cb_AbstractMethod_AbstractMethod_V;
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod;
+		if (cb_AbstractMethod_AbstractMethod_V == null)
+			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
+		return cb_AbstractMethod_AbstractMethod_V;
 	}
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -29,13 +29,13 @@ public partial class MyClass : Java.Lang.Object {
 	{
 	}
 
-	static Delegate? cb_echo_arrayLjava_lang_CharSequence_;
+	static Delegate? cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_;
 #pragma warning disable 0169
 	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
 	{
-		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
-			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
-		return cb_echo_arrayLjava_lang_CharSequence_;
+		if (cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ == null)
+			cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
+		return cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_;
 	}
 
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -49,13 +49,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate cb_get_Count;
+	static Delegate cb_get_Count_get_Count_I;
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count;
+		if (cb_get_Count_get_Count_I == null)
+			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
+		return cb_get_Count_get_Count_I;
 	}
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
@@ -65,13 +65,13 @@ public partial class MyClass {
 	}
 #pragma warning restore 0169
 
-	static Delegate cb_set_Count_I;
+	static Delegate cb_set_Count_set_Count_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_I;
+		if (cb_set_Count_set_Count_I_V == null)
+			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
+		return cb_set_Count_set_Count_I_V;
 	}
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -105,13 +105,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate cb_get_Key;
+	static Delegate cb_get_Key_get_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key;
+		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
+			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
+		return cb_get_Key_get_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
@@ -121,13 +121,13 @@ public partial class MyClass {
 	}
 #pragma warning restore 0169
 
-	static Delegate cb_set_Key_Ljava_lang_String_;
+	static Delegate cb_set_Key_set_Key_Ljava_lang_String__V;
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_Ljava_lang_String_;
+		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
+			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
+		return cb_set_Key_set_Key_Ljava_lang_String__V;
 	}
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
@@ -188,13 +188,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate cb_get_AbstractCount;
+	static Delegate cb_get_AbstractCount_get_AbstractCount_I;
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount;
+		if (cb_get_AbstractCount_get_AbstractCount_I == null)
+			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
+		return cb_get_AbstractCount_get_AbstractCount_I;
 	}
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
@@ -204,13 +204,13 @@ public partial class MyClass {
 	}
 #pragma warning restore 0169
 
-	static Delegate cb_set_AbstractCount_I;
+	static Delegate cb_set_AbstractCount_set_AbstractCount_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_I;
+		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
+			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
+		return cb_set_AbstractCount_set_AbstractCount_I_V;
 	}
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -230,13 +230,13 @@ public partial class MyClass {
 		set; 
 	}
 
-	static Delegate cb_GetCountForKey_Ljava_lang_String_;
+	static Delegate cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_Ljava_lang_String_;
+		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
+			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 	}
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
@@ -264,13 +264,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate cb_Key;
+	static Delegate cb_Key_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key;
+		if (cb_Key_Key_Ljava_lang_String_ == null)
+			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
+		return cb_Key_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
@@ -303,13 +303,13 @@ public partial class MyClass {
 		}
 	}
 
-	static Delegate cb_AbstractMethod;
+	static Delegate cb_AbstractMethod_AbstractMethod_V;
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod;
+		if (cb_AbstractMethod_AbstractMethod_V == null)
+			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
+		return cb_AbstractMethod_AbstractMethod_V;
 	}
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -7,13 +7,13 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[Register ("DoDeclaration", "()V", "GetDoDeclarationHandler:java.code.IMyInterfaceInvoker, MyAssembly")]
 	void DoDeclaration ();
 
-	private static Delegate cb_DoDefault;
+	private static Delegate cb_DoDefault_DoDefault_V;
 #pragma warning disable 0169
 	private static Delegate GetDoDefaultHandler ()
 	{
-		if (cb_DoDefault == null)
-			cb_DoDefault = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDefault));
-		return cb_DoDefault;
+		if (cb_DoDefault_DoDefault_V == null)
+			cb_DoDefault_DoDefault_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDefault));
+		return cb_DoDefault_DoDefault_V;
 	}
 
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
@@ -91,13 +91,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_DoDeclaration;
+	static Delegate cb_DoDeclaration_DoDeclaration_V;
 #pragma warning disable 0169
 	static Delegate GetDoDeclarationHandler ()
 	{
-		if (cb_DoDeclaration == null)
-			cb_DoDeclaration = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDeclaration));
-		return cb_DoDeclaration;
+		if (cb_DoDeclaration_DoDeclaration_V == null)
+			cb_DoDeclaration_DoDeclaration_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDeclaration));
+		return cb_DoDeclaration_DoDeclaration_V;
 	}
 
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -66,13 +66,13 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_OnAnimationEnd_I;
+	static Delegate cb_OnAnimationEnd_OnAnimationEnd_I_Z;
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IHandler ()
 	{
-		if (cb_OnAnimationEnd_I == null)
-			cb_OnAnimationEnd_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
-		return cb_OnAnimationEnd_I;
+		if (cb_OnAnimationEnd_OnAnimationEnd_I_Z == null)
+			cb_OnAnimationEnd_OnAnimationEnd_I_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
+		return cb_OnAnimationEnd_OnAnimationEnd_I_Z;
 	}
 
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
@@ -92,13 +92,13 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 		return JNIEnv.CallBooleanMethod (((global::Java.Lang.Object) this).Handle, id_OnAnimationEnd_I, __args);
 	}
 
-	static Delegate cb_OnAnimationEnd_II;
+	static Delegate cb_OnAnimationEnd_OnAnimationEnd_II_Z;
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IIHandler ()
 	{
-		if (cb_OnAnimationEnd_II == null)
-			cb_OnAnimationEnd_II = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
-		return cb_OnAnimationEnd_II;
+		if (cb_OnAnimationEnd_OnAnimationEnd_II_Z == null)
+			cb_OnAnimationEnd_OnAnimationEnd_II_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
+		return cb_OnAnimationEnd_OnAnimationEnd_II_Z;
 	}
 
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -130,13 +130,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_get_Count;
+	static Delegate cb_get_Count_get_Count_I;
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count == null)
-			cb_get_Count = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count;
+		if (cb_get_Count_get_Count_I == null)
+			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
+		return cb_get_Count_get_Count_I;
 	}
 
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
@@ -146,13 +146,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 #pragma warning restore 0169
 
-	static Delegate cb_set_Count_I;
+	static Delegate cb_set_Count_set_Count_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_I == null)
-			cb_set_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_I;
+		if (cb_set_Count_set_Count_I_V == null)
+			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
+		return cb_set_Count_set_Count_I_V;
 	}
 
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -179,13 +179,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		}
 	}
 
-	static Delegate cb_get_Key;
+	static Delegate cb_get_Key_get_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key == null)
-			cb_get_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key;
+		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
+			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
+		return cb_get_Key_get_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
@@ -195,13 +195,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 #pragma warning restore 0169
 
-	static Delegate cb_set_Key_Ljava_lang_String_;
+	static Delegate cb_set_Key_set_Key_Ljava_lang_String__V;
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_Ljava_lang_String_ == null)
-			cb_set_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_Ljava_lang_String_;
+		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
+			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
+		return cb_set_Key_set_Key_Ljava_lang_String__V;
 	}
 
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
@@ -231,13 +231,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		}
 	}
 
-	static Delegate cb_get_AbstractCount;
+	static Delegate cb_get_AbstractCount_get_AbstractCount_I;
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount == null)
-			cb_get_AbstractCount = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount;
+		if (cb_get_AbstractCount_get_AbstractCount_I == null)
+			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
+		return cb_get_AbstractCount_get_AbstractCount_I;
 	}
 
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
@@ -247,13 +247,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	}
 #pragma warning restore 0169
 
-	static Delegate cb_set_AbstractCount_I;
+	static Delegate cb_set_AbstractCount_set_AbstractCount_I_V;
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_I == null)
-			cb_set_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_I;
+		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
+			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
+		return cb_set_AbstractCount_set_AbstractCount_I_V;
 	}
 
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
@@ -280,13 +280,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		}
 	}
 
-	static Delegate cb_GetCountForKey_Ljava_lang_String_;
+	static Delegate cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_Ljava_lang_String_ == null)
-			cb_GetCountForKey_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_Ljava_lang_String_;
+		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
+			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
 	}
 
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
@@ -311,13 +311,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		return __ret;
 	}
 
-	static Delegate cb_Key;
+	static Delegate cb_Key_Key_Ljava_lang_String_;
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key == null)
-			cb_Key = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key;
+		if (cb_Key_Key_Ljava_lang_String_ == null)
+			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
+		return cb_Key_Key_Ljava_lang_String_;
 	}
 
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
@@ -335,13 +335,13 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 		return JNIEnv.GetString (JNIEnv.CallObjectMethod (((global::Java.Lang.Object) this).Handle, id_Key), JniHandleOwnership.TransferLocalRef);
 	}
 
-	static Delegate cb_AbstractMethod;
+	static Delegate cb_AbstractMethod_AbstractMethod_V;
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod == null)
-			cb_AbstractMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod;
+		if (cb_AbstractMethod_AbstractMethod_V == null)
+			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
+		return cb_AbstractMethod_AbstractMethod_V;
 	}
 
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -3,13 +3,13 @@
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
-	private static Delegate cb_DoSomething;
+	private static Delegate cb_DoSomething_DoSomething_V;
 #pragma warning disable 0169
 	private static Delegate GetDoSomethingHandler ()
 	{
-		if (cb_DoSomething == null)
-			cb_DoSomething = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
-		return cb_DoSomething;
+		if (cb_DoSomething_DoSomething_V == null)
+			cb_DoSomething_DoSomething_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
+		return cb_DoSomething_DoSomething_V;
 	}
 
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -3,13 +3,13 @@
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
-	private static Delegate cb_get_Value;
+	private static Delegate cb_get_Value_get_Value_I;
 #pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
-		if (cb_get_Value == null)
-			cb_get_Value = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
-		return cb_get_Value;
+		if (cb_get_Value_get_Value_I == null)
+			cb_get_Value_get_Value_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
+		return cb_get_Value_get_Value_I;
 	}
 
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
@@ -19,13 +19,13 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	}
 #pragma warning restore 0169
 
-	private static Delegate cb_set_Value_I;
+	private static Delegate cb_set_Value_set_Value_I_V;
 #pragma warning disable 0169
 	private static Delegate Getset_Value_IHandler ()
 	{
-		if (cb_set_Value_I == null)
-			cb_set_Value_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Value_I));
-		return cb_set_Value_I;
+		if (cb_set_Value_set_Value_I_V == null)
+			cb_set_Value_set_Value_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Value_I));
+		return cb_set_Value_set_Value_I_V;
 	}
 
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -3,13 +3,13 @@
 public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/IMyInterface", typeof (IMyInterface), isInterface: true);
 
-	private static Delegate cb_get_Value;
+	private static Delegate cb_get_Value_get_Value_I;
 #pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
-		if (cb_get_Value == null)
-			cb_get_Value = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
-		return cb_get_Value;
+		if (cb_get_Value_get_Value_I == null)
+			cb_get_Value_get_Value_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
+		return cb_get_Value_get_Value_I;
 	}
 
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -62,13 +62,13 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_DoSomething;
+	static Delegate cb_DoSomething_DoSomething_V;
 #pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
-		if (cb_DoSomething == null)
-			cb_DoSomething = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
-		return cb_DoSomething;
+		if (cb_DoSomething_DoSomething_V == null)
+			cb_DoSomething_DoSomething_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
+		return cb_DoSomething_DoSomething_V;
 	}
 
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -29,13 +29,13 @@ public partial class MyClass : Java.Lang.Object {
 	{
 	}
 
-	static Delegate cb_echo_arrayLjava_lang_CharSequence_;
+	static Delegate cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_;
 #pragma warning disable 0169
 	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
 	{
-		if (cb_echo_arrayLjava_lang_CharSequence_ == null)
-			cb_echo_arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
-		return cb_echo_arrayLjava_lang_CharSequence_;
+		if (cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ == null)
+			cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
+		return cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_;
 	}
 
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -97,13 +97,13 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_getBar;
+	static Delegate cb_getBar_GetBar_I;
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar;
+		if (cb_getBar_GetBar_I == null)
+			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
+		return cb_getBar_GetBar_I;
 	}
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -73,13 +73,13 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 			JNIEnv.DeleteLocalRef (local_ref);
 		}
 
-		static Delegate cb_getBar;
+		static Delegate cb_getBar_GetBar_I;
 #pragma warning disable 0169
 		static Delegate GetGetBarHandler ()
 		{
-			if (cb_getBar == null)
-				cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-			return cb_getBar;
+			if (cb_getBar_GetBar_I == null)
+				cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
+			return cb_getBar_GetBar_I;
 		}
 
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
@@ -157,13 +157,13 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_getBar;
+	static Delegate cb_getBar_GetBar_I;
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar;
+		if (cb_getBar_GetBar_I == null)
+			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
+		return cb_getBar_GetBar_I;
 	}
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -64,13 +64,13 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_getBar;
+	static Delegate cb_getBar_GetBar_I;
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar;
+		if (cb_getBar_GetBar_I == null)
+			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
+		return cb_getBar_GetBar_I;
 	}
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
@@ -157,13 +157,13 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 		JNIEnv.DeleteLocalRef (local_ref);
 	}
 
-	static Delegate cb_getBar;
+	static Delegate cb_getBar_GetBar_I;
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar == null)
-			cb_getBar = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar;
+		if (cb_getBar_GetBar_I == null)
+			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
+		return cb_getBar_GetBar_I;
 	}
 
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_baseMethod;
+		static Delegate cb_baseMethod_BaseMethod_V;
 #pragma warning disable 0169
 		static Delegate GetBaseMethodHandler ()
 		{
-			if (cb_baseMethod == null)
-				cb_baseMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
-			return cb_baseMethod;
+			if (cb_baseMethod_BaseMethod_V == null)
+				cb_baseMethod_BaseMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
+			return cb_baseMethod_BaseMethod_V;
 		}
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -63,13 +63,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_foo;
+		static Delegate cb_foo_Foo_V;
 #pragma warning disable 0169
 		static Delegate GetFooHandler ()
 		{
-			if (cb_foo == null)
-				cb_foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-			return cb_foo;
+			if (cb_foo_Foo_V == null)
+				cb_foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
+			return cb_foo_Foo_V;
 		}
 
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -50,13 +50,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_extendedMethod;
+		static Delegate cb_extendedMethod_ExtendedMethod_V;
 #pragma warning disable 0169
 		static Delegate GetExtendedMethodHandler ()
 		{
-			if (cb_extendedMethod == null)
-				cb_extendedMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_ExtendedMethod));
-			return cb_extendedMethod;
+			if (cb_extendedMethod_ExtendedMethod_V == null)
+				cb_extendedMethod_ExtendedMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_ExtendedMethod));
+			return cb_extendedMethod_ExtendedMethod_V;
 		}
 
 		static void n_ExtendedMethod (IntPtr jnienv, IntPtr native__this)
@@ -75,13 +75,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_baseMethod;
+		static Delegate cb_baseMethod_BaseMethod_V;
 #pragma warning disable 0169
 		static Delegate GetBaseMethodHandler ()
 		{
-			if (cb_baseMethod == null)
-				cb_baseMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
-			return cb_baseMethod;
+			if (cb_baseMethod_BaseMethod_V == null)
+				cb_baseMethod_BaseMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
+			return cb_baseMethod_BaseMethod_V;
 		}
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -57,13 +57,13 @@ namespace Xamarin.Test {
 			{
 			}
 
-			static Delegate cb_foo;
+			static Delegate cb_foo_Foo_V;
 #pragma warning disable 0169
 			static Delegate GetFooHandler ()
 			{
-				if (cb_foo == null)
-					cb_foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-				return cb_foo;
+				if (cb_foo_Foo_V == null)
+					cb_foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
+				return cb_foo_Foo_V;
 			}
 
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
@@ -129,13 +129,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_foo;
+		static Delegate cb_foo_Foo_V;
 #pragma warning disable 0169
 		static Delegate GetFooHandler ()
 		{
-			if (cb_foo == null)
-				cb_foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-			return cb_foo;
+			if (cb_foo_Foo_V == null)
+				cb_foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
+			return cb_foo_Foo_V;
 		}
 
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -63,13 +63,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_baseMethod;
+		static Delegate cb_baseMethod_BaseMethod_V;
 #pragma warning disable 0169
 		static Delegate GetBaseMethodHandler ()
 		{
-			if (cb_baseMethod == null)
-				cb_baseMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
-			return cb_baseMethod;
+			if (cb_baseMethod_BaseMethod_V == null)
+				cb_baseMethod_BaseMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
+			return cb_baseMethod_BaseMethod_V;
 		}
 
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_getAdapter;
+		static Delegate cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_;
 #pragma warning disable 0169
 		static Delegate GetGetAdapterHandler ()
 		{
-			if (cb_getAdapter == null)
-				cb_getAdapter = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
-			return cb_getAdapter;
+			if (cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_ == null)
+				cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
+			return cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_;
 		}
 
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
@@ -62,13 +62,13 @@ namespace Xamarin.Test {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setAdapter_Lxamarin_test_SpinnerAdapter_;
+		static Delegate cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V;
 #pragma warning disable 0169
 		static Delegate GetSetAdapter_Lxamarin_test_SpinnerAdapter_Handler ()
 		{
-			if (cb_setAdapter_Lxamarin_test_SpinnerAdapter_ == null)
-				cb_setAdapter_Lxamarin_test_SpinnerAdapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_SpinnerAdapter_));
-			return cb_setAdapter_Lxamarin_test_SpinnerAdapter_;
+			if (cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V == null)
+				cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_SpinnerAdapter_));
+			return cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V;
 		}
 
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -47,13 +47,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_getAdapter;
+		static Delegate cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_;
 #pragma warning disable 0169
 		static Delegate GetGetAdapterHandler ()
 		{
-			if (cb_getAdapter == null)
-				cb_getAdapter = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
-			return cb_getAdapter;
+			if (cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_ == null)
+				cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
+			return cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_;
 		}
 
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
@@ -63,13 +63,13 @@ namespace Xamarin.Test {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setAdapter_Lxamarin_test_Adapter_;
+		static Delegate cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V;
 #pragma warning disable 0169
 		static Delegate GetSetAdapter_Lxamarin_test_Adapter_Handler ()
 		{
-			if (cb_setAdapter_Lxamarin_test_Adapter_ == null)
-				cb_setAdapter_Lxamarin_test_Adapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_Adapter_));
-			return cb_setAdapter_Lxamarin_test_Adapter_;
+			if (cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V == null)
+				cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_Adapter_));
+			return cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V;
 		}
 
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_GenericReturn;
+		static Delegate cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_;
 #pragma warning disable 0169
 		static Delegate GetGenericReturnHandler ()
 		{
-			if (cb_GenericReturn == null)
-				cb_GenericReturn = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GenericReturn));
-			return cb_GenericReturn;
+			if (cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_ == null)
+				cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GenericReturn));
+			return cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_;
 		}
 
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -66,13 +66,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_getSomeColor;
+		static Delegate cb_getSomeColor_GetSomeColor_I;
 #pragma warning disable 0169
 		static Delegate GetGetSomeColorHandler ()
 		{
-			if (cb_getSomeColor == null)
-				cb_getSomeColor = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeColor));
-			return cb_getSomeColor;
+			if (cb_getSomeColor_GetSomeColor_I == null)
+				cb_getSomeColor_GetSomeColor_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeColor));
+			return cb_getSomeColor_GetSomeColor_I;
 		}
 
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
@@ -82,13 +82,13 @@ namespace Xamarin.Test {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setSomeColor_I;
+		static Delegate cb_setSomeColor_SetSomeColor_I_V;
 #pragma warning disable 0169
 		static Delegate GetSetSomeColor_IHandler ()
 		{
-			if (cb_setSomeColor_I == null)
-				cb_setSomeColor_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeColor_I));
-			return cb_setSomeColor_I;
+			if (cb_setSomeColor_SetSomeColor_I_V == null)
+				cb_setSomeColor_SetSomeColor_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeColor_I));
+			return cb_setSomeColor_SetSomeColor_I_V;
 		}
 
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -24,13 +24,13 @@ namespace Java.Lang {
 			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
-		static Delegate cb_getMessage;
+		static Delegate cb_getMessage_GetMessage_Ljava_lang_String_;
 #pragma warning disable 0169
 		static Delegate GetGetMessageHandler ()
 		{
-			if (cb_getMessage == null)
-				cb_getMessage = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
-			return cb_getMessage;
+			if (cb_getMessage_GetMessage_Ljava_lang_String_ == null)
+				cb_getMessage_GetMessage_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
+			return cb_getMessage_GetMessage_Ljava_lang_String_;
 		}
 
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_usePartial_I;
+		static Delegate cb_usePartial_UsePartial_I_Ljava_lang_String_;
 #pragma warning disable 0169
 		static Delegate GetUsePartial_IHandler ()
 		{
-			if (cb_usePartial_I == null)
-				cb_usePartial_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_UsePartial_I));
-			return cb_usePartial_I;
+			if (cb_usePartial_UsePartial_I_Ljava_lang_String_ == null)
+				cb_usePartial_UsePartial_I_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_UsePartial_I));
+			return cb_usePartial_UsePartial_I_Ljava_lang_String_;
 		}
 
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -42,13 +42,13 @@ namespace Android.Text {
 		{
 		}
 
-		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
+		static Delegate cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_Ljava_lang_Object_;
+			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
+				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 		}
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -45,13 +45,13 @@ namespace Android.Text {
 		{
 		}
 
-		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
+		static Delegate cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_Ljava_lang_Object_;
+			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
+				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 		}
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -89,13 +89,13 @@ namespace Android.Text {
 			}
 		}
 
-		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
+		static Delegate cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_Ljava_lang_Object_;
+			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
+				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 		}
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -46,13 +46,13 @@ namespace Android.Text {
 		{
 		}
 
-		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
+		static Delegate cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_Ljava_lang_Object_;
+			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
+				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 		}
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -57,13 +57,13 @@ namespace Android.Views {
 			{
 			}
 
-			static Delegate cb_onClick_Landroid_view_View_;
+			static Delegate cb_onClick_OnClick_Landroid_view_View__V;
 #pragma warning disable 0169
 			static Delegate GetOnClick_Landroid_view_View_Handler ()
 			{
-				if (cb_onClick_Landroid_view_View_ == null)
-					cb_onClick_Landroid_view_View_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_OnClick_Landroid_view_View_));
-				return cb_onClick_Landroid_view_View_;
+				if (cb_onClick_OnClick_Landroid_view_View__V == null)
+					cb_onClick_OnClick_Landroid_view_View__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_OnClick_Landroid_view_View_));
+				return cb_onClick_OnClick_Landroid_view_View__V;
 			}
 
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
@@ -146,13 +146,13 @@ namespace Android.Views {
 		{
 		}
 
-		static Delegate cb_setOnClickListener_Landroid_view_View_OnClickListener_;
+		static Delegate cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V;
 #pragma warning disable 0169
 		static Delegate GetSetOnClickListener_Landroid_view_View_OnClickListener_Handler ()
 		{
-			if (cb_setOnClickListener_Landroid_view_View_OnClickListener_ == null)
-				cb_setOnClickListener_Landroid_view_View_OnClickListener_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnClickListener_Landroid_view_View_OnClickListener_));
-			return cb_setOnClickListener_Landroid_view_View_OnClickListener_;
+			if (cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V == null)
+				cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnClickListener_Landroid_view_View_OnClickListener_));
+			return cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V;
 		}
 
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
@@ -177,13 +177,13 @@ namespace Android.Views {
 			}
 		}
 
-		static Delegate cb_setOn123Listener_Landroid_view_View_OnClickListener_;
+		static Delegate cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V;
 #pragma warning disable 0169
 		static Delegate GetSetOn123Listener_Landroid_view_View_OnClickListener_Handler ()
 		{
-			if (cb_setOn123Listener_Landroid_view_View_OnClickListener_ == null)
-				cb_setOn123Listener_Landroid_view_View_OnClickListener_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOn123Listener_Landroid_view_View_OnClickListener_));
-			return cb_setOn123Listener_Landroid_view_View_OnClickListener_;
+			if (cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V == null)
+				cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOn123Listener_Landroid_view_View_OnClickListener_));
+			return cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V;
 		}
 
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
@@ -208,13 +208,13 @@ namespace Android.Views {
 			}
 		}
 
-		static Delegate cb_addTouchables_Ljava_util_ArrayList_;
+		static Delegate cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V;
 #pragma warning disable 0169
 		static Delegate GetAddTouchables_Ljava_util_ArrayList_Handler ()
 		{
-			if (cb_addTouchables_Ljava_util_ArrayList_ == null)
-				cb_addTouchables_Ljava_util_ArrayList_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_AddTouchables_Ljava_util_ArrayList_));
-			return cb_addTouchables_Ljava_util_ArrayList_;
+			if (cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V == null)
+				cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_AddTouchables_Ljava_util_ArrayList_));
+			return cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V;
 		}
 
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -44,13 +44,13 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		{
 		}
 
-		static Delegate cb_requiresSecureDecoderComponent_Ljava_lang_String_;
+		static Delegate cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z;
 #pragma warning disable 0169
 		static Delegate GetRequiresSecureDecoderComponent_Ljava_lang_String_Handler ()
 		{
-			if (cb_requiresSecureDecoderComponent_Ljava_lang_String_ == null)
-				cb_requiresSecureDecoderComponent_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_RequiresSecureDecoderComponent_Ljava_lang_String_));
-			return cb_requiresSecureDecoderComponent_Ljava_lang_String_;
+			if (cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z == null)
+				cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_RequiresSecureDecoderComponent_Ljava_lang_String_));
+			return cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z;
 		}
 
 		static bool n_RequiresSecureDecoderComponent_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -45,13 +45,13 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		{
 		}
 
-		static Delegate cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+		static Delegate cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V;
 #pragma warning disable 0169
 		static Delegate GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler ()
 		{
-			if (cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB == null)
-				cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLLIIL_V (n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB));
-			return cb_onEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB;
+			if (cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V == null)
+				cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLLIIL_V (n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB));
+			return cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V;
 		}
 
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
@@ -215,13 +215,13 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		{
 		}
 
-		static Delegate cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+		static Delegate cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V;
 #pragma warning disable 0169
 		static Delegate GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler ()
 		{
-			if (cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ == null)
-				cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_));
-			return cb_setOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_;
+			if (cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V == null)
+				cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_));
+			return cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V;
 		}
 
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -44,13 +44,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_close;
+		static Delegate cb_close_Close_V;
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close;
+			if (cb_close_Close_V == null)
+				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
+			return cb_close_Close_V;
 		}
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -44,13 +44,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_close;
+		static Delegate cb_close_Close_V;
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close;
+			if (cb_close_Close_V == null)
+				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
+			return cb_close_Close_V;
 		}
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_close;
+		static Delegate cb_close_Close_V;
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close;
+			if (cb_close_Close_V == null)
+				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
+			return cb_close_Close_V;
 		}
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_irrelevant;
+		static Delegate cb_irrelevant_Irrelevant_V;
 #pragma warning disable 0169
 		static Delegate GetIrrelevantHandler ()
 		{
-			if (cb_irrelevant == null)
-				cb_irrelevant = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Irrelevant));
-			return cb_irrelevant;
+			if (cb_irrelevant_Irrelevant_V == null)
+				cb_irrelevant_Irrelevant_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Irrelevant));
+			return cb_irrelevant_Irrelevant_V;
 		}
 
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
@@ -73,13 +73,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_close;
+		static Delegate cb_close_Close_V;
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close;
+			if (cb_close_Close_V == null)
+				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
+			return cb_close_Close_V;
 		}
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -60,13 +60,13 @@ namespace Xamarin.Test {
 				{
 				}
 
-				static Delegate cb_build_I;
+				static Delegate cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_;
 #pragma warning disable 0169
 				static Delegate GetBuild_IHandler ()
 				{
-					if (cb_build_I == null)
-						cb_build_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_Build_I));
-					return cb_build_I;
+					if (cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_ == null)
+						cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_Build_I));
+					return cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_;
 				}
 
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -50,13 +50,13 @@ namespace Xamarin.Test {
 			{
 			}
 
-			static Delegate cb_setCustomDimension_I;
+			static Delegate cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_;
 #pragma warning disable 0169
 			static Delegate GetSetCustomDimension_IHandler ()
 			{
-				if (cb_setCustomDimension_I == null)
-					cb_setCustomDimension_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
-				return cb_setCustomDimension_I;
+				if (cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_ == null)
+					cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
+				return cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_;
 			}
 
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
@@ -110,13 +110,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_getHandle;
+		static Delegate cb_getHandle_GetHandle_I;
 #pragma warning disable 0169
 		static Delegate GetGetHandleHandler ()
 		{
-			if (cb_getHandle == null)
-				cb_getHandle = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetHandle));
-			return cb_getHandle;
+			if (cb_getHandle_GetHandle_I == null)
+				cb_getHandle_GetHandle_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetHandle));
+			return cb_getHandle_GetHandle_I;
 		}
 
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -47,13 +47,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_setCustomDimension_I;
+		static Delegate cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_;
 #pragma warning disable 0169
 		static Delegate GetSetCustomDimension_IHandler ()
 		{
-			if (cb_setCustomDimension_I == null)
-				cb_setCustomDimension_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
-			return cb_setCustomDimension_I;
+			if (cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_ == null)
+				cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
+			return cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_;
 		}
 
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -66,13 +66,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_getType;
+		static Delegate cb_getType_GetType_arrayI;
 #pragma warning disable 0169
 		static Delegate GetGetTypeHandler ()
 		{
-			if (cb_getType == null)
-				cb_getType = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetType));
-			return cb_getType;
+			if (cb_getType_GetType_arrayI == null)
+				cb_getType_GetType_arrayI = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetType));
+			return cb_getType_GetType_arrayI;
 		}
 
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
@@ -94,13 +94,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+		static Delegate cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I;
 #pragma warning disable 0169
 		static Delegate GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler ()
 		{
-			if (cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ == null)
-				cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLL_I (n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_));
-			return cb_handle_Ljava_lang_Object_Ljava_lang_Throwable_;
+			if (cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I == null)
+				cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLL_I (n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_));
+			return cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I;
 		}
 
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
@@ -130,13 +130,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_IntegerMethod;
+		static Delegate cb_IntegerMethod_IntegerMethod_I;
 #pragma warning disable 0169
 		static Delegate GetIntegerMethodHandler ()
 		{
-			if (cb_IntegerMethod == null)
-				cb_IntegerMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_IntegerMethod));
-			return cb_IntegerMethod;
+			if (cb_IntegerMethod_IntegerMethod_I == null)
+				cb_IntegerMethod_IntegerMethod_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_IntegerMethod));
+			return cb_IntegerMethod_IntegerMethod_I;
 		}
 
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
@@ -158,13 +158,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_VoidMethod;
+		static Delegate cb_VoidMethod_VoidMethod_V;
 #pragma warning disable 0169
 		static Delegate GetVoidMethodHandler ()
 		{
-			if (cb_VoidMethod == null)
-				cb_VoidMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_VoidMethod));
-			return cb_VoidMethod;
+			if (cb_VoidMethod_VoidMethod_V == null)
+				cb_VoidMethod_VoidMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_VoidMethod));
+			return cb_VoidMethod_VoidMethod_V;
 		}
 
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
@@ -185,13 +185,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_StringMethod;
+		static Delegate cb_StringMethod_StringMethod_Ljava_lang_String_;
 #pragma warning disable 0169
 		static Delegate GetStringMethodHandler ()
 		{
-			if (cb_StringMethod == null)
-				cb_StringMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_StringMethod));
-			return cb_StringMethod;
+			if (cb_StringMethod_StringMethod_Ljava_lang_String_ == null)
+				cb_StringMethod_StringMethod_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_StringMethod));
+			return cb_StringMethod_StringMethod_Ljava_lang_String_;
 		}
 
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
@@ -213,13 +213,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_ObjectMethod;
+		static Delegate cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_;
 #pragma warning disable 0169
 		static Delegate GetObjectMethodHandler ()
 		{
-			if (cb_ObjectMethod == null)
-				cb_ObjectMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_ObjectMethod));
-			return cb_ObjectMethod;
+			if (cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_ == null)
+				cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_ObjectMethod));
+			return cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_;
 		}
 
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
@@ -241,13 +241,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_;
+		static Delegate cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V;
 #pragma warning disable 0169
 		static Delegate GetVoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_Handler ()
 		{
-			if (cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ == null)
-				cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLIL_V (n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_));
-			return cb_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_;
+			if (cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V == null)
+				cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLIL_V (n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_));
+			return cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V;
 		}
 
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
@@ -277,14 +277,14 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_ObsoleteMethod;
+		static Delegate cb_ObsoleteMethod_ObsoleteMethod_I;
 #pragma warning disable 0169
 		[global::System.Obsolete]
 		static Delegate GetObsoleteMethodHandler ()
 		{
-			if (cb_ObsoleteMethod == null)
-				cb_ObsoleteMethod = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_ObsoleteMethod));
-			return cb_ObsoleteMethod;
+			if (cb_ObsoleteMethod_ObsoleteMethod_I == null)
+				cb_ObsoleteMethod_ObsoleteMethod_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_ObsoleteMethod));
+			return cb_ObsoleteMethod_ObsoleteMethod_I;
 		}
 
 		[global::System.Obsolete]
@@ -308,13 +308,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_ArrayListTest_Ljava_util_ArrayList_;
+		static Delegate cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V;
 #pragma warning disable 0169
 		static Delegate GetArrayListTest_Ljava_util_ArrayList_Handler ()
 		{
-			if (cb_ArrayListTest_Ljava_util_ArrayList_ == null)
-				cb_ArrayListTest_Ljava_util_ArrayList_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ArrayListTest_Ljava_util_ArrayList_));
-			return cb_ArrayListTest_Ljava_util_ArrayList_;
+			if (cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V == null)
+				cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ArrayListTest_Ljava_util_ArrayList_));
+			return cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V;
 		}
 
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -46,13 +46,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_getSomeInteger;
+		static Delegate cb_getSomeInteger_GetSomeInteger_I;
 #pragma warning disable 0169
 		static Delegate GetGetSomeIntegerHandler ()
 		{
-			if (cb_getSomeInteger == null)
-				cb_getSomeInteger = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeInteger));
-			return cb_getSomeInteger;
+			if (cb_getSomeInteger_GetSomeInteger_I == null)
+				cb_getSomeInteger_GetSomeInteger_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeInteger));
+			return cb_getSomeInteger_GetSomeInteger_I;
 		}
 
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
@@ -62,13 +62,13 @@ namespace Xamarin.Test {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setSomeInteger_I;
+		static Delegate cb_setSomeInteger_SetSomeInteger_I_V;
 #pragma warning disable 0169
 		static Delegate GetSetSomeInteger_IHandler ()
 		{
-			if (cb_setSomeInteger_I == null)
-				cb_setSomeInteger_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeInteger_I));
-			return cb_setSomeInteger_I;
+			if (cb_setSomeInteger_SetSomeInteger_I_V == null)
+				cb_setSomeInteger_SetSomeInteger_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeInteger_I));
+			return cb_setSomeInteger_SetSomeInteger_I_V;
 		}
 
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
@@ -88,13 +88,13 @@ namespace Xamarin.Test {
 			set; 
 		}
 
-		static Delegate cb_getSomeObjectProperty;
+		static Delegate cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_;
 #pragma warning disable 0169
 		static Delegate GetGetSomeObjectPropertyHandler ()
 		{
-			if (cb_getSomeObjectProperty == null)
-				cb_getSomeObjectProperty = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeObjectProperty));
-			return cb_getSomeObjectProperty;
+			if (cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_ == null)
+				cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeObjectProperty));
+			return cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_;
 		}
 
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
@@ -104,13 +104,13 @@ namespace Xamarin.Test {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setSomeObjectProperty_Ljava_lang_Object_;
+		static Delegate cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V;
 #pragma warning disable 0169
 		static Delegate GetSetSomeObjectProperty_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setSomeObjectProperty_Ljava_lang_Object_ == null)
-				cb_setSomeObjectProperty_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeObjectProperty_Ljava_lang_Object_));
-			return cb_setSomeObjectProperty_Ljava_lang_Object_;
+			if (cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V == null)
+				cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeObjectProperty_Ljava_lang_Object_));
+			return cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V;
 		}
 
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
@@ -131,13 +131,13 @@ namespace Xamarin.Test {
 			set; 
 		}
 
-		static Delegate cb_getSomeString;
+		static Delegate cb_getSomeString_GetSomeString_Ljava_lang_String_;
 #pragma warning disable 0169
 		static Delegate GetGetSomeStringHandler ()
 		{
-			if (cb_getSomeString == null)
-				cb_getSomeString = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeString));
-			return cb_getSomeString;
+			if (cb_getSomeString_GetSomeString_Ljava_lang_String_ == null)
+				cb_getSomeString_GetSomeString_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeString));
+			return cb_getSomeString_GetSomeString_Ljava_lang_String_;
 		}
 
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
@@ -147,13 +147,13 @@ namespace Xamarin.Test {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setSomeString_Ljava_lang_String_;
+		static Delegate cb_setSomeString_SetSomeString_Ljava_lang_String__V;
 #pragma warning disable 0169
 		static Delegate GetSetSomeString_Ljava_lang_String_Handler ()
 		{
-			if (cb_setSomeString_Ljava_lang_String_ == null)
-				cb_setSomeString_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeString_Ljava_lang_String_));
-			return cb_setSomeString_Ljava_lang_String_;
+			if (cb_setSomeString_SetSomeString_Ljava_lang_String__V == null)
+				cb_setSomeString_SetSomeString_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeString_Ljava_lang_String_));
+			return cb_setSomeString_SetSomeString_Ljava_lang_String__V;
 		}
 
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -47,13 +47,13 @@ namespace Xamarin.Test {
 		{
 		}
 
-		static Delegate cb_setA_Ljava_lang_Object_;
+		static Delegate cb_setA_SetA_Ljava_lang_Object__V;
 #pragma warning disable 0169
 		static Delegate GetSetA_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setA_Ljava_lang_Object_ == null)
-				cb_setA_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetA_Ljava_lang_Object_));
-			return cb_setA_Ljava_lang_Object_;
+			if (cb_setA_SetA_Ljava_lang_Object__V == null)
+				cb_setA_SetA_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetA_Ljava_lang_Object_));
+			return cb_setA_SetA_Ljava_lang_Object__V;
 		}
 
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
@@ -80,13 +80,13 @@ namespace Xamarin.Test {
 			}
 		}
 
-		static Delegate cb_listTest_Ljava_util_List_;
+		static Delegate cb_listTest_ListTest_Ljava_util_List__V;
 #pragma warning disable 0169
 		static Delegate GetListTest_Ljava_util_List_Handler ()
 		{
-			if (cb_listTest_Ljava_util_List_ == null)
-				cb_listTest_Ljava_util_List_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ListTest_Ljava_util_List_));
-			return cb_listTest_Ljava_util_List_;
+			if (cb_listTest_ListTest_Ljava_util_List__V == null)
+				cb_listTest_ListTest_Ljava_util_List__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ListTest_Ljava_util_List_));
+			return cb_listTest_ListTest_Ljava_util_List__V;
 		}
 
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -68,13 +68,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_write_I;
+		static Delegate cb_write_Write_I_V;
 #pragma warning disable 0169
 		static Delegate GetWrite_IHandler ()
 		{
-			if (cb_write_I == null)
-				cb_write_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
-			return cb_write_I;
+			if (cb_write_Write_I_V == null)
+				cb_write_Write_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
+			return cb_write_Write_I_V;
 		}
 
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -46,13 +46,13 @@ namespace Java.IO {
 		{
 		}
 
-		static Delegate cb_printStackTrace;
+		static Delegate cb_printStackTrace_PrintStackTrace_V;
 #pragma warning disable 0169
 		static Delegate GetPrintStackTraceHandler ()
 		{
-			if (cb_printStackTrace == null)
-				cb_printStackTrace = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_PrintStackTrace));
-			return cb_printStackTrace;
+			if (cb_printStackTrace_PrintStackTrace_V == null)
+				cb_printStackTrace_PrintStackTrace_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_PrintStackTrace));
+			return cb_printStackTrace_PrintStackTrace_V;
 		}
 
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -63,13 +63,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_available;
+		static Delegate cb_available_Available_I;
 #pragma warning disable 0169
 		static Delegate GetAvailableHandler ()
 		{
-			if (cb_available == null)
-				cb_available = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Available));
-			return cb_available;
+			if (cb_available_Available_I == null)
+				cb_available_Available_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Available));
+			return cb_available_Available_I;
 		}
 
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
@@ -91,13 +91,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_close;
+		static Delegate cb_close_Close_V;
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close;
+			if (cb_close_Close_V == null)
+				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
+			return cb_close_Close_V;
 		}
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
@@ -118,13 +118,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_mark_I;
+		static Delegate cb_mark_Mark_I_V;
 #pragma warning disable 0169
 		static Delegate GetMark_IHandler ()
 		{
-			if (cb_mark_I == null)
-				cb_mark_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Mark_I));
-			return cb_mark_I;
+			if (cb_mark_Mark_I_V == null)
+				cb_mark_Mark_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Mark_I));
+			return cb_mark_Mark_I_V;
 		}
 
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
@@ -147,13 +147,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_markSupported;
+		static Delegate cb_markSupported_MarkSupported_Z;
 #pragma warning disable 0169
 		static Delegate GetMarkSupportedHandler ()
 		{
-			if (cb_markSupported == null)
-				cb_markSupported = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_Z (n_MarkSupported));
-			return cb_markSupported;
+			if (cb_markSupported_MarkSupported_Z == null)
+				cb_markSupported_MarkSupported_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_Z (n_MarkSupported));
+			return cb_markSupported_MarkSupported_Z;
 		}
 
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
@@ -175,13 +175,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_read;
+		static Delegate cb_read_Read_I;
 #pragma warning disable 0169
 		static Delegate GetReadHandler ()
 		{
-			if (cb_read == null)
-				cb_read = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Read));
-			return cb_read;
+			if (cb_read_Read_I == null)
+				cb_read_Read_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Read));
+			return cb_read_Read_I;
 		}
 
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
@@ -195,13 +195,13 @@ namespace Java.IO {
 		[Register ("read", "()I", "GetReadHandler")]
 		public abstract int Read ();
 
-		static Delegate cb_read_arrayB;
+		static Delegate cb_read_Read_arrayB_I;
 #pragma warning disable 0169
 		static Delegate GetRead_arrayBHandler ()
 		{
-			if (cb_read_arrayB == null)
-				cb_read_arrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_Read_arrayB));
-			return cb_read_arrayB;
+			if (cb_read_Read_arrayB_I == null)
+				cb_read_Read_arrayB_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_Read_arrayB));
+			return cb_read_Read_arrayB_I;
 		}
 
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
@@ -235,13 +235,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_read_arrayBII;
+		static Delegate cb_read_Read_arrayBII_I;
 #pragma warning disable 0169
 		static Delegate GetRead_arrayBIIHandler ()
 		{
-			if (cb_read_arrayBII == null)
-				cb_read_arrayBII = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_I (n_Read_arrayBII));
-			return cb_read_arrayBII;
+			if (cb_read_Read_arrayBII_I == null)
+				cb_read_Read_arrayBII_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_I (n_Read_arrayBII));
+			return cb_read_Read_arrayBII_I;
 		}
 
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
@@ -277,13 +277,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_reset;
+		static Delegate cb_reset_Reset_V;
 #pragma warning disable 0169
 		static Delegate GetResetHandler ()
 		{
-			if (cb_reset == null)
-				cb_reset = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Reset));
-			return cb_reset;
+			if (cb_reset_Reset_V == null)
+				cb_reset_Reset_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Reset));
+			return cb_reset_Reset_V;
 		}
 
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
@@ -304,13 +304,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_skip_J;
+		static Delegate cb_skip_Skip_J_J;
 #pragma warning disable 0169
 		static Delegate GetSkip_JHandler ()
 		{
-			if (cb_skip_J == null)
-				cb_skip_J = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPJ_J (n_Skip_J));
-			return cb_skip_J;
+			if (cb_skip_Skip_J_J == null)
+				cb_skip_Skip_J_J = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPJ_J (n_Skip_J));
+			return cb_skip_Skip_J_J;
 		}
 
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -63,13 +63,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_close;
+		static Delegate cb_close_Close_V;
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close == null)
-				cb_close = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close;
+			if (cb_close_Close_V == null)
+				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
+			return cb_close_Close_V;
 		}
 
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
@@ -90,13 +90,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_flush;
+		static Delegate cb_flush_Flush_V;
 #pragma warning disable 0169
 		static Delegate GetFlushHandler ()
 		{
-			if (cb_flush == null)
-				cb_flush = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Flush));
-			return cb_flush;
+			if (cb_flush_Flush_V == null)
+				cb_flush_Flush_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Flush));
+			return cb_flush_Flush_V;
 		}
 
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
@@ -117,13 +117,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_write_arrayB;
+		static Delegate cb_write_Write_arrayB_V;
 #pragma warning disable 0169
 		static Delegate GetWrite_arrayBHandler ()
 		{
-			if (cb_write_arrayB == null)
-				cb_write_arrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Write_arrayB));
-			return cb_write_arrayB;
+			if (cb_write_Write_arrayB_V == null)
+				cb_write_Write_arrayB_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Write_arrayB));
+			return cb_write_Write_arrayB_V;
 		}
 
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
@@ -155,13 +155,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_write_arrayBII;
+		static Delegate cb_write_Write_arrayBII_V;
 #pragma warning disable 0169
 		static Delegate GetWrite_arrayBIIHandler ()
 		{
-			if (cb_write_arrayBII == null)
-				cb_write_arrayBII = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_V (n_Write_arrayBII));
-			return cb_write_arrayBII;
+			if (cb_write_Write_arrayBII_V == null)
+				cb_write_Write_arrayBII_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_V (n_Write_arrayBII));
+			return cb_write_Write_arrayBII_V;
 		}
 
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
@@ -195,13 +195,13 @@ namespace Java.IO {
 			}
 		}
 
-		static Delegate cb_write_I;
+		static Delegate cb_write_Write_I_V;
 #pragma warning disable 0169
 		static Delegate GetWrite_IHandler ()
 		{
-			if (cb_write_I == null)
-				cb_write_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
-			return cb_write_I;
+			if (cb_write_Write_I_V == null)
+				cb_write_Write_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
+			return cb_write_Write_I_V;
 		}
 
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)

--- a/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -24,13 +24,13 @@ namespace Java.Lang {
 			get { return _members.JniPeerType.PeerReference.Handle; }
 		}
 
-		static Delegate cb_getMessage;
+		static Delegate cb_getMessage_GetMessage_Ljava_lang_String_;
 #pragma warning disable 0169
 		static Delegate GetGetMessageHandler ()
 		{
-			if (cb_getMessage == null)
-				cb_getMessage = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
-			return cb_getMessage;
+			if (cb_getMessage_GetMessage_Ljava_lang_String_ == null)
+				cb_getMessage_GetMessage_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
+			return cb_getMessage_GetMessage_Ljava_lang_String_;
 		}
 
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -61,13 +61,13 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 		}
 	}
 
-	static Delegate cb_Foo;
+	static Delegate cb_Foo_Foo_V;
 #pragma warning disable 0169
 	static Delegate GetFooHandler ()
 	{
-		if (cb_Foo == null)
-			cb_Foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-		return cb_Foo;
+		if (cb_Foo_Foo_V == null)
+			cb_Foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
+		return cb_Foo_Foo_V;
 	}
 
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -42,13 +42,13 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 	{
 	}
 
-	static Delegate cb_Foo;
+	static Delegate cb_Foo_Foo_V;
 #pragma warning disable 0169
 	static Delegate GetFooHandler ()
 	{
-		if (cb_Foo == null)
-			cb_Foo = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-		return cb_Foo;
+		if (cb_Foo_Foo_V == null)
+			cb_Foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
+		return cb_Foo_Foo_V;
 	}
 
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
@@ -49,13 +49,13 @@ namespace Java.Util {
 		{
 		}
 
-		static Delegate cb_add_Ljava_lang_Object_;
+		static Delegate cb_add_Add_Ljava_lang_Object__Z;
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
-			if (cb_add_Ljava_lang_Object_ == null)
-				cb_add_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
-			return cb_add_Ljava_lang_Object_;
+			if (cb_add_Add_Ljava_lang_Object__Z == null)
+				cb_add_Add_Ljava_lang_Object__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
+			return cb_add_Add_Ljava_lang_Object__Z;
 		}
 
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
@@ -82,13 +82,13 @@ namespace Java.Util {
 			}
 		}
 
-		static Delegate cb_clear;
+		static Delegate cb_clear_Clear_V;
 #pragma warning disable 0169
 		static Delegate GetClearHandler ()
 		{
-			if (cb_clear == null)
-				cb_clear = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
-			return cb_clear;
+			if (cb_clear_Clear_V == null)
+				cb_clear_Clear_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
+			return cb_clear_Clear_V;
 		}
 
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
@@ -49,13 +49,13 @@ namespace Java.Util {
 		{
 		}
 
-		static Delegate cb_add_Ljava_lang_Object_;
+		static Delegate cb_add_Add_Ljava_lang_Object__Z;
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
-			if (cb_add_Ljava_lang_Object_ == null)
-				cb_add_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
-			return cb_add_Ljava_lang_Object_;
+			if (cb_add_Add_Ljava_lang_Object__Z == null)
+				cb_add_Add_Ljava_lang_Object__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
+			return cb_add_Add_Ljava_lang_Object__Z;
 		}
 
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
@@ -82,13 +82,13 @@ namespace Java.Util {
 			}
 		}
 
-		static Delegate cb_clear;
+		static Delegate cb_clear_Clear_V;
 #pragma warning disable 0169
 		static Delegate GetClearHandler ()
 		{
-			if (cb_clear == null)
-				cb_clear = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
-			return cb_clear;
+			if (cb_clear_Clear_V == null)
+				cb_clear_Clear_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
+			return cb_clear_Clear_V;
 		}
 
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
@@ -47,13 +47,13 @@ namespace Java.Util {
 		{
 		}
 
-		static Delegate cb_add_Ljava_lang_Object_;
+		static Delegate cb_add_Add_Ljava_lang_Object__Z;
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
-			if (cb_add_Ljava_lang_Object_ == null)
-				cb_add_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
-			return cb_add_Ljava_lang_Object_;
+			if (cb_add_Add_Ljava_lang_Object__Z == null)
+				cb_add_Add_Ljava_lang_Object__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
+			return cb_add_Add_Ljava_lang_Object__Z;
 		}
 
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
@@ -80,13 +80,13 @@ namespace Java.Util {
 			}
 		}
 
-		static Delegate cb_clear;
+		static Delegate cb_clear_Clear_V;
 #pragma warning disable 0169
 		static Delegate GetClearHandler ()
 		{
-			if (cb_clear == null)
-				cb_clear = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
-			return cb_clear;
+			if (cb_clear_Clear_V == null)
+				cb_clear_Clear_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
+			return cb_clear_Clear_V;
 		}
 
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -63,13 +63,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_SetObject_arrayB;
+		static Delegate cb_SetObject_SetObject_arrayB_V;
 #pragma warning disable 0169
 		static Delegate GetSetObject_arrayBHandler ()
 		{
-			if (cb_SetObject_arrayB == null)
-				cb_SetObject_arrayB = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayB));
-			return cb_SetObject_arrayB;
+			if (cb_SetObject_SetObject_arrayB_V == null)
+				cb_SetObject_SetObject_arrayB_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayB));
+			return cb_SetObject_SetObject_arrayB_V;
 		}
 
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -63,13 +63,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_getObject;
+		static Delegate cb_getObject_GetObject_Ljava_lang_Object_;
 #pragma warning disable 0169
 		static Delegate GetGetObjectHandler ()
 		{
-			if (cb_getObject == null)
-				cb_getObject = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
-			return cb_getObject;
+			if (cb_getObject_GetObject_Ljava_lang_Object_ == null)
+				cb_getObject_GetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
+			return cb_getObject_GetObject_Ljava_lang_Object_;
 		}
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
@@ -79,13 +79,13 @@ namespace Test.ME {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setObject_Ljava_lang_Object_;
+		static Delegate cb_setObject_SetObject_Ljava_lang_Object__V;
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setObject_Ljava_lang_Object_ == null)
-				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
-			return cb_setObject_Ljava_lang_Object_;
+			if (cb_setObject_SetObject_Ljava_lang_Object__V == null)
+				cb_setObject_SetObject_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
+			return cb_setObject_SetObject_Ljava_lang_Object__V;
 		}
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -63,13 +63,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_SetObject_arrayLjava_lang_String_;
+		static Delegate cb_SetObject_SetObject_arrayLjava_lang_String__V;
 #pragma warning disable 0169
 		static Delegate GetSetObject_arrayLjava_lang_String_Handler ()
 		{
-			if (cb_SetObject_arrayLjava_lang_String_ == null)
-				cb_SetObject_arrayLjava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayLjava_lang_String_));
-			return cb_SetObject_arrayLjava_lang_String_;
+			if (cb_SetObject_SetObject_arrayLjava_lang_String__V == null)
+				cb_SetObject_SetObject_arrayLjava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayLjava_lang_String_));
+			return cb_SetObject_SetObject_arrayLjava_lang_String__V;
 		}
 
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -63,13 +63,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_getObject;
+		static Delegate cb_getObject_GetObject_Ljava_lang_String_;
 #pragma warning disable 0169
 		static Delegate GetGetObjectHandler ()
 		{
-			if (cb_getObject == null)
-				cb_getObject = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
-			return cb_getObject;
+			if (cb_getObject_GetObject_Ljava_lang_String_ == null)
+				cb_getObject_GetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
+			return cb_getObject_GetObject_Ljava_lang_String_;
 		}
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
@@ -79,13 +79,13 @@ namespace Test.ME {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_SetObject_Ljava_lang_String_;
+		static Delegate cb_SetObject_SetObject_Ljava_lang_String__V;
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_String_Handler ()
 		{
-			if (cb_SetObject_Ljava_lang_String_ == null)
-				cb_SetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_String_));
-			return cb_SetObject_Ljava_lang_String_;
+			if (cb_SetObject_SetObject_Ljava_lang_String__V == null)
+				cb_SetObject_SetObject_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_String_));
+			return cb_SetObject_SetObject_Ljava_lang_String__V;
 		}
 
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -45,13 +45,13 @@ namespace Test.ME {
 		{
 		}
 
-		static Delegate cb_SetObject_Ljava_lang_Object_;
+		static Delegate cb_SetObject_SetObject_Ljava_lang_Object__V;
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
-			if (cb_SetObject_Ljava_lang_Object_ == null)
-				cb_SetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
-			return cb_SetObject_Ljava_lang_Object_;
+			if (cb_SetObject_SetObject_Ljava_lang_Object__V == null)
+				cb_SetObject_SetObject_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
+			return cb_SetObject_SetObject_Ljava_lang_Object__V;
 		}
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -51,13 +51,13 @@ namespace Test.ME {
 		{
 		}
 
-		static Delegate cb_getObject;
+		static Delegate cb_getObject_GetObject_Ljava_lang_Object_;
 #pragma warning disable 0169
 		static Delegate GetGetObjectHandler ()
 		{
-			if (cb_getObject == null)
-				cb_getObject = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
-			return cb_getObject;
+			if (cb_getObject_GetObject_Ljava_lang_Object_ == null)
+				cb_getObject_GetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
+			return cb_getObject_GetObject_Ljava_lang_Object_;
 		}
 
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
@@ -67,13 +67,13 @@ namespace Test.ME {
 		}
 #pragma warning restore 0169
 
-		static Delegate cb_setObject_Ljava_lang_Object_;
+		static Delegate cb_setObject_SetObject_Ljava_lang_Object__V;
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setObject_Ljava_lang_Object_ == null)
-				cb_setObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
-			return cb_setObject_Ljava_lang_Object_;
+			if (cb_setObject_SetObject_Ljava_lang_Object__V == null)
+				cb_setObject_SetObject_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
+			return cb_setObject_SetObject_Ljava_lang_Object__V;
 		}
 
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -106,13 +106,13 @@ namespace Test.ME {
 		{
 		}
 
-		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
+		static Delegate cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_Ljava_lang_Object_;
+			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
+				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 		}
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
@@ -137,13 +137,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_append_Ljava_lang_CharSequence_;
+		static Delegate cb_append_Append_Ljava_lang_CharSequence__V;
 #pragma warning disable 0169
 		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_append_Ljava_lang_CharSequence_ == null)
-				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
-			return cb_append_Ljava_lang_CharSequence_;
+			if (cb_append_Append_Ljava_lang_CharSequence__V == null)
+				cb_append_Append_Ljava_lang_CharSequence__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
+			return cb_append_Append_Ljava_lang_CharSequence__V;
 		}
 
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
@@ -168,13 +168,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_identity_Ljava_lang_CharSequence_;
+		static Delegate cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_;
 #pragma warning disable 0169
 		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_identity_Ljava_lang_CharSequence_ == null)
-				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
-			return cb_identity_Ljava_lang_CharSequence_;
+			if (cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ == null)
+				cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
+			return cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_;
 		}
 
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -84,13 +84,13 @@ namespace Test.ME {
 			}
 		}
 
-		static Delegate cb_getSpanFlags_Ljava_lang_Object_;
+		static Delegate cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_Ljava_lang_Object_ == null)
-				cb_getSpanFlags_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_Ljava_lang_Object_;
+			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
+				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
 		}
 
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
@@ -106,13 +106,13 @@ namespace Test.ME {
 		[Register ("getSpanFlags", "(Ljava/lang/Object;)I", "GetGetSpanFlags_Ljava_lang_Object_Handler")]
 		public abstract int GetSpanFlags (global::Java.Lang.Object tag);
 
-		static Delegate cb_append_Ljava_lang_CharSequence_;
+		static Delegate cb_append_Append_Ljava_lang_CharSequence__V;
 #pragma warning disable 0169
 		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_append_Ljava_lang_CharSequence_ == null)
-				cb_append_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
-			return cb_append_Ljava_lang_CharSequence_;
+			if (cb_append_Append_Ljava_lang_CharSequence__V == null)
+				cb_append_Append_Ljava_lang_CharSequence__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
+			return cb_append_Append_Ljava_lang_CharSequence__V;
 		}
 
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
@@ -134,13 +134,13 @@ namespace Test.ME {
 			jls_value?.Dispose ();
 		}
 
-		static Delegate cb_identity_Ljava_lang_CharSequence_;
+		static Delegate cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_;
 #pragma warning disable 0169
 		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_identity_Ljava_lang_CharSequence_ == null)
-				cb_identity_Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
-			return cb_identity_Ljava_lang_CharSequence_;
+			if (cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ == null)
+				cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
+			return cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_;
 		}
 
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -45,13 +45,13 @@ namespace Java.Lang {
 		{
 		}
 
-		static Delegate cb_compareTo_Ljava_lang_Object_;
+		static Delegate cb_compareTo_CompareTo_Ljava_lang_Object__I;
 #pragma warning disable 0169
 		static Delegate GetCompareTo_Ljava_lang_Object_Handler ()
 		{
-			if (cb_compareTo_Ljava_lang_Object_ == null)
-				cb_compareTo_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_CompareTo_Ljava_lang_Object_));
-			return cb_compareTo_Ljava_lang_Object_;
+			if (cb_compareTo_CompareTo_Ljava_lang_Object__I == null)
+				cb_compareTo_CompareTo_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_CompareTo_Ljava_lang_Object_));
+			return cb_compareTo_CompareTo_Ljava_lang_Object__I;
 		}
 
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Method.cs
@@ -165,7 +165,7 @@ namespace MonoDroid.Generation
 
 		public string ConnectorName => $"Get{Name}{IDSignature}Handler";
 
-		public string EscapedCallbackName => IdentifierValidator.CreateValidIdentifier ($"cb_{JavaName}{IDSignature}", true);
+		public string EscapedCallbackName => IdentifierValidator.CreateValidIdentifier ($"cb_{JavaName}_{Name}{IDSignatureWithReturnType}", true);
 
 		public string EscapedIdName => IdentifierValidator.CreateValidIdentifier ($"id_{JavaName}{IDSignature}", true);
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -84,7 +84,11 @@ namespace MonoDroid.Generation
 			return sb.ToString ();
 		}
 
-		internal string IDSignature => Parameters.Count > 0 ? "_" + Parameters.JniSignature.Replace ("/", "_").Replace ("`", "_").Replace (";", "_").Replace ("$", "_").Replace ("[", "array") : string.Empty;
+		internal string IDSignature => Parameters.Count > 0 ? "_" + EscapeSignature (Parameters.JniSignature) : string.Empty;
+
+		internal string IDSignatureWithReturnType => IDSignature + (this is Method method ? "_" + EscapeSignature (method.RetVal.JniName) : "");
+
+		internal string EscapeSignature (string value) => value.Replace ("/", "_").Replace ("`", "_").Replace (";", "_").Replace ("$", "_").Replace ("[", "array");
 
 		public virtual bool IsGeneric => Parameters.HasGeneric;
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/java-interop/issues/1155

When binding Java methods, we can come across "bridge" methods that have the same name and parameters as a "real" method.  They only differ by return type.

```xml
<method abstract="false" deprecated="not deprecated" final="false" name="setDetectorMode" jni-signature="(I)Lcom/google/mlkit/vision/objects/defaults/ObjectDetectorOptions$Builder;" bridge="false" native="false" return="com.google.mlkit.vision.objects.defaults.ObjectDetectorOptions.Builder" jni-return="Lcom/google/mlkit/vision/objects/defaults/ObjectDetectorOptions$Builder;" static="false" synchronized="false" synthetic="false" visibility="public" return-not-null="true">
  <parameter name="detectorMode" type="int" jni-type="I" />
</method>
<method abstract="false" deprecated="not deprecated" final="true" name="setDetectorMode" jni-signature="(I)Lcom/google/mlkit/vision/objects/ObjectDetectorOptionsBase$Builder;" bridge="true" native="false" return="java.lang.Object" jni-return="Lcom/google/mlkit/vision/objects/ObjectDetectorOptionsBase$Builder;" static="false" synchronized="false" synthetic="true" visibility="public" return-not-null="true">
  <parameter name="p0" type="int" jni-type="I" />
</method>
```

When bound in C#, this causes an issue because 2 methods cannot have the same name and parameters.

```csharp
using Com.Google.Mlkit.Vision.Objects;

public Defaults.ObjectDetectorOptions.Builder SetDetectorMode (int detectorMode) { ... }
public ObjectDetectorOptions.Builder SetDetectorMode (int p0) { ... }
```

We can use `managedName` metadata to rename one of these methods, however we generate the callback delegate field with the algorithm `$"cb_{JavaName}{IDSignature}"`, so this name is still used twice, preventing C# compilation.

```csharp
static Delegate cb_setDetectorMode_I;
static Delegate cb_setDetectorMode_I;
```
The solution is to add both the _managed_ name and the return type to the callback naming algorithm to ensure that it will always be unique for a method. (`$"cb_{JavaName}_{Name}{IDSignatureWithReturnType}"`)

```csharp
static Delegate cb_setDetectorMode_SetDetectorMode_I_Lcom_google_mlkit_vision_objects_defaults_ObjectDetectorOptions$Builder_;
static Delegate cb_setDetectorMode_SetDetectorMode2_I_Lcom_google_mlkit_vision_objects_ObjectDetectorOptions$Builder_;
```

XA test PR: https://github.com/dotnet/android/pull/9172