### PR TITLE
[Java.Interop.Tools.Cecil] Unroll TypeDefinitionRocks iterators.

### DIFF
--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/MethodDefinitionRocks.cs
@@ -20,7 +20,9 @@ namespace Java.Interop.Tools.Cecil {
 			if (method.IsStatic || method.IsNewSlot || !method.IsVirtual)
 				return method;
 
-			foreach (var baseType in method.DeclaringType.GetBaseTypes (resolver)) {
+			TypeDefinition? baseType = method.DeclaringType;
+
+			while ((baseType = baseType.GetBaseType (resolver)) != null) {
 				foreach (var m in baseType.Methods) {
 					if (!m.IsConstructor &&
 							m.Name == method.Name &&

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Make a few small performance related changes to `TypeDefinitionRocks`:

- Calling `TypeDefinitionRocks.Get[TypeAnd]BaseTypes` provides a convenient API to work with, however it creates an iterator method and related generated infrastructure code, which causes a small amount of overhead.  For performance sensitive hot paths, do the looping through base types at the call site instead.

This change provides a minor (3.5ms) speedup on the test case of calling `HasJavaPeer` on every type in `Mono.Android`, but we call these paths enough that it might add up.

| Method               | Mean     | Error    | StdDev   | Gen0      | Gen1      | Gen2     | Allocated |
|--------------------- |---------:|---------:|---------:|----------:|----------:|---------:|----------:|
| Original_HasJavaPeer | 25.13 ms | 0.608 ms | 1.791 ms | 1093.7500 | 1031.2500 | 812.5000 |  37.83 MB |
| Unrolled_HasJavaPeer         | 21.62 ms | 0.426 ms | 0.569 ms | 1093.7500 | 1031.2500 | 843.7500 |   36.9 MB |


- Change `TypeDefinitionRocks.HasJavaPeer` to always exit immediately if the type is an `interface`, as an interface cannot have any of the listed base types.

- Create `IsSubclassOfAny` and `ImplementsAnyInterface` method variants that can replace patterns where we iterate through base types or interfaces multiple times looking for multiple values.