### PR TITLE
Pin .NET 8 to '8.0.303'.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -25,7 +25,7 @@ parameters:
 variables:
   RunningOnCI: true
   Build.Configuration: Release
-  DotNetCoreVersion: 8.x
+  DotNetCoreVersion: 8.0.303
   DotNetTargetFramework: net8.0
   NetCoreTargetFrameworkPathSuffix: -$(DotNetTargetFramework)
   1ESWindowsPool: AzurePipelines-EO


### PR DESCRIPTION
Beginning in .NET 8 '8.0.400', we hit the following error on CI:

```
/var/folders/cy/09t6wxdj6qn64c5q9_kr6czr0000gn/T/MSBuildTemprunner/tmp58b6b197481a4eb7b080ec79e70515ad.exec.
cmd: line 2:  7199 Bus error: 10           "/Users/runner/hostedtoolcache/dotnet/dotnet" 
"/Users/runner/work/1/s/bin/Release-net8.0//jnimarshalmethod-gen.dll" "/Users/runner/work/1/s/samples/Hello-
NativeAOTFromJNI/bin/Release/Hello-NativeAOTFromJNI.dll" -v -v --keeptemp -L "/Users/runner/work/1/s/samples/Hello-
NativeAOTFromJNI/bin/Release/"

##[error]samples/Hello-NativeAOTFromJNI/Hello-NativeAOTFromJNI.targets(44,5): Error MSB3073: The command 
""/Users/runner/hostedtoolcache/dotnet/dotnet" "/Users/runner/work/1/s/bin/Release-net8.0//jnimarshalmethod-gen.dll" 
"/Users/runner/work/1/s/samples/Hello-NativeAOTFromJNI/bin/Release/Hello-NativeAOTFromJNI.dll" -v -v --keeptemp -L 
"/Users/runner/work/1/s/samples/Hello-NativeAOTFromJNI/bin/Release/" " exited with code 138.
```

Pin to .NET '8.0.303' for now while this regression is investigated/fixed in .NET.