### PR TITLE
[generator] Cache static final field values.

### DIFF
--- a/src/Xamarin.SourceWriter/Models/TypeReferenceWriter.cs
+++ b/src/Xamarin.SourceWriter/Models/TypeReferenceWriter.cs
@@ -40,12 +40,17 @@ namespace Xamarin.SourceWriter
 
 		public virtual void WriteTypeReference (CodeWriter writer)
 		{
-			if (Namespace.HasValue ())
-				writer.Write ($"{Namespace}.{Name}{NullableOperator} ");
-			else
-				writer.Write ($"{Name}{NullableOperator} ");
+			writer.Write ($"{ToString ()} ");
 		}
 
 		string NullableOperator => Nullable ? "?" : string.Empty;
+
+		public override string ToString ()
+		{
+			if (Namespace.HasValue ())
+				return $"{Namespace}.{Name}{NullableOperator}";
+
+			return $"{Name}{NullableOperator}";
+		}
 	}
 }

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteCachedReferenceTypeField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteCachedReferenceTypeField.txt
@@ -1,0 +1,24 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Java.Interop.JniTypeSignature ("java/code/MyClass", GenerateJavaPeer=false)]
+public partial class MyClass {
+	private static java.code.Example? _field_cache;
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	public static java.code.Example? field {
+		get {
+			if (_field_cache != null) return (java.code.Example)_field_cache;
+
+			const string __id = "field.Ljava/code/Example;";
+
+			var __v = _members.StaticFields.GetObjectValue (__id);
+			return (java.code.Example?)(_field_cache = global::Java.Interop.JniEnvironment.Runtime.ValueManager.GetValue<java.code.Example? >(ref __v, JniObjectReferenceOptions.Copy));
+		}
+	}
+
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	protected MyClass (ref JniObjectReference reference, JniObjectReferenceOptions options) : base (ref reference, options)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteCachedValueTypeField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/JavaInterop1/WriteCachedValueTypeField.txt
@@ -1,0 +1,24 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Java.Interop.JniTypeSignature ("java/code/MyClass", GenerateJavaPeer=false)]
+public partial class MyClass {
+	private static int? _field_cache;
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	public static int field {
+		get {
+			if (_field_cache != null) return (int)_field_cache;
+
+			const string __id = "field.I";
+
+			var __v = _members.StaticFields.GetInt32Value (__id);
+			return (int)(_field_cache = __v);
+		}
+	}
+
+	static readonly JniPeerMembers _members = new JniPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	protected MyClass (ref JniObjectReference reference, JniObjectReferenceOptions options) : base (ref reference, options)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteCachedReferenceTypeField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteCachedReferenceTypeField.txt
@@ -1,0 +1,29 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass {
+	private static java.code.Example? _field_cache;
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public static java.code.Example? field {
+		get {
+			if (_field_cache != null) return (java.code.Example)_field_cache;
+
+			const string __id = "field.Ljava/code/Example;";
+
+			var __v = _members.StaticFields.GetObjectValue (__id);
+			return (java.code.Example?)(_field_cache = global::Java.Lang.Object.GetObject<java.code.Example> (__v.Handle, JniHandleOwnership.TransferLocalRef));
+		}
+	}
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	internal static IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteCachedValueTypeField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteCachedValueTypeField.txt
@@ -1,0 +1,29 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass {
+	private static int? _field_cache;
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public static int field {
+		get {
+			if (_field_cache != null) return (int)_field_cache;
+
+			const string __id = "field.I";
+
+			var __v = _members.StaticFields.GetInt32Value (__id);
+			return (int)(_field_cache = __v);
+		}
+	}
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	internal static IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCachedReferenceTypeField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCachedReferenceTypeField.txt
@@ -1,0 +1,26 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass {
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public static java.code.Example field {
+		get {
+			const string __id = "field.Ljava/code/Example;";
+
+			var __v = _members.StaticFields.GetObjectValue (__id);
+			return global::Java.Lang.Object.GetObject<java.code.Example> (__v.Handle, JniHandleOwnership.TransferLocalRef);
+		}
+	}
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	internal static IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCachedValueTypeField.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteCachedValueTypeField.txt
@@ -1,0 +1,26 @@
+// Metadata.xml XPath class reference: path="/api/package[@name='java.code']/class[@name='MyClass']"
+[global::Android.Runtime.Register ("java/code/MyClass", DoNotGenerateAcw=true)]
+public partial class MyClass {
+
+	// Metadata.xml XPath field reference: path="/api/package[@name='java.code']/class[@name='MyClass']/field[@name='field']"
+	[Register ("field")]
+	public static int field {
+		get {
+			const string __id = "field.I";
+
+			var __v = _members.StaticFields.GetInt32Value (__id);
+			return __v;
+		}
+	}
+
+	static readonly JniPeerMembers _members = new XAPeerMembers ("java/code/MyClass", typeof (MyClass));
+
+	internal static IntPtr class_ref {
+		get { return _members.JniPeerType.PeerReference.Handle; }
+	}
+
+	protected MyClass (IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer)
+	{
+	}
+
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1644,5 +1644,47 @@ namespace generatortests
 			// Ignore nullable operator so this test works on all generators  ;)
 			Assert.AreEqual (expected.NormalizeLineEndings (), writer.ToString ().NormalizeLineEndings ().Replace ("?", ""));
 		}
+
+		[Test]
+		public void WriteCachedReferenceTypeField ()
+		{
+			options.SymbolTable.AddType (new TestClass (null, "Java.Lang.Object"));
+			var eClass = new TestClass ("Java.Lang.Object", "java.code.Example");
+			options.SymbolTable.AddType (eClass);
+
+			var klass = new TestClass ("Object", "java.code.MyClass");
+
+			var field = SupportTypeBuilder.CreateField ("field", options, "java.code.Example", true);
+			field.IsFinal = true;
+
+			klass.Fields.Add (field);
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			AssertTargetedExpected (nameof (WriteCachedReferenceTypeField), writer.ToString ());
+		}
+
+		[Test]
+		public void WriteCachedValueTypeField ()
+		{
+			options.SymbolTable.AddType (new TestClass (null, "Java.Lang.Object"));
+			var eClass = new TestClass ("Java.Lang.Object", "java.code.Example");
+			options.SymbolTable.AddType (eClass);
+
+			var klass = new TestClass ("Object", "java.code.MyClass");
+
+			var field = SupportTypeBuilder.CreateField ("field", options, "int", true);
+			field.IsFinal = true;
+
+			klass.Fields.Add (field);
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			AssertTargetedExpected (nameof (WriteCachedValueTypeField), writer.ToString ());
+		}
 	}
 }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -42,6 +42,8 @@ namespace MonoDroid.Generation
 
 		public bool NeedsProperty => !IsStatic || !IsFinal || string.IsNullOrEmpty (Value) || Symbol.IsArray || !primitive_types.Contains (Symbol.JavaName);
 
+		public string CachedMemberName => $"_{Name}_cache";
+
 		public bool Validate (CodeGenerationOptions opt, GenericParameterDefinitionList type_params, CodeGeneratorContext context)
 		{
 			Symbol = opt.SymbolTable.Lookup (TypeName, type_params);

--- a/tools/generator/generator.csproj
+++ b/tools/generator/generator.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <DefineConstants>$(DefineConstants);GENERATOR;HAVE_CECIL;JCW_ONLY_TYPE_NAMES</DefineConstants>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/java-interop/issues/1243

Consider the [`Thread.State` enum](https://developer.android.com/reference/java/lang/Thread.State):

```java
/* partial */ class Thread {
    public static final /* partial */ enum State {
        NEW, RUNNABLE, BLOCKED, WAITING, TIMED_WAITING, TERMINATED
    }
}
```

This "actually" is a class with *fields* for each enum value:

```console
% javap java.lang.Thread.State
Compiled from "Thread.java"
public final class java.lang.Thread$State extends java.lang.Enum<java.lang.Thread$State> {
  public static final java.lang.Thread$State NEW;
  public static final java.lang.Thread$State RUNNABLE;
  public static final java.lang.Thread$State BLOCKED;
  public static final java.lang.Thread$State WAITING;
  public static final java.lang.Thread$State TIMED_WAITING;
  public static final java.lang.Thread$State TERMINATED;
  public static java.lang.Thread$State[] values();
  public static java.lang.Thread$State valueOf(java.lang.String);
  static {};
}
```

When we bind it, we bind the fields as properties:

https://github.com/dotnet/java-interop/blob/fcad3368815dffd0f38f64384aa21b0b65367d68/src/Java.Base-ref.cs#L5490-L5506

However, each of those properties involves a ValueManager lookup:

```csharp
namespace Java.Lang {
	public partial class Thread {
		public sealed partial class State : global::Java.Lang.Enum {
			public static global::Java.Lang.Thread.State? Runnable {
				get {
					const string __id = "RUNNABLE.Ljava/lang/Thread$State;";

					var __v = _members.StaticFields.GetObjectValue (__id);
					return global::Java.Interop.JniEnvironment.Runtime.ValueManager.GetValue<global::Java.Lang.Thread.State? >(ref __v, JniObjectReferenceOptions.Copy);
				}
			}
		}
	}
}
```

This is JavaInterop1, not XAJavaInterop1, but .NET for Android isn't much different:

```csharp
			public static Java.Lang.Thread.State? Runnable {
				get {
					const string __id = "RUNNABLE.Ljava/lang/Thread$State;";

					var __v = _members.StaticFields.GetObjectValue (__id);
					return global::Java.Lang.Object.GetObject<Java.Lang.Thread.State> (__v.Handle, JniHandleOwnership.TransferLocalRef);
				}
			}
```

The problem is that value lookup is not fast -- identity hash code needs to be obtained, locks obtained, etc. -- to the point that repeated enum lookups can actually show up in profiles.

Instead, update property generation for all `final` fields to *cache* the return value.  This means we'd only need to call `StaticFields.GetObjectValue()` and "GetValue" *once*, instead of once per-access:

```csharp
			global::Java.Lang.Thread.State? _Runnable_cache;
			public static global::Java.Lang.Thread.State? Runnable {
				get {
					if (_Runnable_cache != null) return _Runnable_cache;
					const string __id = "RUNNABLE.Ljava/lang/Thread$State;";

					var __v = _members.StaticFields.GetObjectValue (__id);
					return _Runnable_cache  = global::Java.Interop.JniEnvironment.Runtime.ValueManager.GetValue<global::Java.Lang.Thread.State? >(ref __v, JniObjectReferenceOptions.Copy);
				}
			}
```

Note there are a few wrinkles here:

- If the field value is `null`, we will set the cached value to `null` which will trigger us to re-request the value. IE: the cache will not work for `null` values.  This likely doesn't occur enough to be a concern.
- The cache field (`_Runnable_cache`) could be a nullable value type or a nullable reference type.  This complicates things as .NET treats these as very different things.  A solution was found using casting that allows us to treat them the same without needing to explicitly use `Nullable.HasValue` or `Nullable.Value`.
- Generating the correct code when NRT is not enabled gets pretty complex, as we then have to track what field types are value types and which are reference types to generate different code. To avoid this complexity, this entire feature is only enabled when NRT is enabled for the binding project.  This includes `Mono.Android`, every AndroidX/GPS library we bind, and every user binding created from our templates (unless the user explicitly disabled NRT).  This limitation should not impact too many bindings.