### PR TITLE
[generator] Add support for `skipInterfaceMethods`.

### DIFF
--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -147,6 +147,10 @@ namespace MonoDroid.Generation
 				}
 			}
 
+			if (elem.Attribute ("skipInterfaceMethods")?.Value is string skip)
+				foreach (var m in skip.Split (new char [] { ',', ' ', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries))
+					klass.SkippedInterfaceMethods.Add (m);
+
 			return klass;
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -11,6 +11,7 @@ namespace MonoDroid.Generation
 	public class ClassGen : GenBase
 	{
 		bool fill_explicit_implementation_started;
+		HashSet<string> skipped_interface_methods;
 
 		public List<Ctor> Ctors { get; private set; } = new List<Ctor> ();
 
@@ -354,6 +355,8 @@ namespace MonoDroid.Generation
 			validated = false;
 			base.ResetValidation ();
 		}
+
+		public HashSet<string> SkippedInterfaceMethods => skipped_interface_methods ??= new HashSet<string> ();
 
 		public override string ToNative (CodeGenerationOptions opt, string varname, Dictionary<string, string> mappings = null)
 		{

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -221,6 +221,8 @@ namespace generator.SourceWriters
 
 				if (context.ContextGeneratedMethods.Any (_ => _.Name == method.Name && _.JniSignature == method.JniSignature))
 					continue;
+				if (klass.SkippedInterfaceMethods.Contains (method.GetSkipInvokerSignature ()))
+					continue;
 
 				for (var cls = klass; cls != null; cls = cls.BaseGen)
 					if (cls.ContainsMethod (method, false) || cls != klass && klass.ExplicitlyImplementedInterfaceMethods.Contains (sig)) {


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/issues/1264

The scenario described in https://github.com/dotnet/java-interop/issues/1264 seems very complex to fix, as we would have to determine if each interface method has a compatible DIM on any other interface in scope.

As a workaround, we can mimic [`skipInvokerMethods`](https://github.com/dotnet/java-interop/pull/1086) with a new `skipInterfaceMethods` metadata that allows us to suppress generation of an `abstract` method in an `abstract class` that implements the interface.

The example in https://github.com/dotnet/java-interop/issues/1264 would be fixed with:

```xml
<attr
  path="/api/package[@name='kotlin.collections']/class[@name='AbstractList']"
  name="skipInterfaceMethods">
    java/util/SequencedCollection.reversed()Ljava/util/SequencedCollection;
</attr>
```

The format is the same as `skipInvokerMethods`.