### PR TITLE
[generator] Fix exception caused by incorrect nested type name.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/ManagedTests.cs
+++ b/tests/generator-Tests/Unit-Tests/ManagedTests.cs
@@ -41,6 +41,15 @@ namespace Com.Mypackage
 
 	[Register ("com/mypackage/service")]
 	public interface IService { }
+
+	[Register ("com/mypackage/FieldClass")]
+	public class FieldClass : Java.Lang.Object
+	{
+		public NestedFieldClass field;
+
+		public class NestedFieldClass : Java.Lang.Object { }
+	}
+
 }
 
 namespace GenericTestClasses
@@ -131,6 +140,21 @@ namespace generatortests
 			Assert.IsFalse (@class.IsFinal);
 			Assert.IsFalse (@class.IsDeprecated);
 			Assert.IsNull (@class.DeprecatedComment);
+		}
+
+		[Test]
+		public void FieldWithNestedType ()
+		{
+			var @class = CecilApiImporter.CreateClass (module.GetType ("Com.Mypackage.FieldClass"), options);
+			var @class2 = CecilApiImporter.CreateClass (module.GetType ("Com.Mypackage.FieldClass/NestedFieldClass"), options);
+
+			options.SymbolTable.AddType (@class);
+			options.SymbolTable.AddType (@class2);
+
+			Assert.IsTrue (@class.Validate (options, new GenericParameterDefinitionList (), new CodeGeneratorContext ()), "@class.Validate failed!");
+
+			// Ensure the front slash is replaced with a period
+			Assert.AreEqual ("Com.Mypackage.FieldClass.NestedFieldClass", @class.Fields [0].TypeName);
 		}
 
 		[Test]

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/CecilApiImporter.cs
@@ -108,7 +108,8 @@ namespace MonoDroid.Generation
 				Visibility = f.IsPublic ? "public" : f.IsFamilyOrAssembly ? "protected internal" : f.IsFamily ? "protected" : f.IsAssembly ? "internal" : "private"
 			};
 
-			field.SetterParameter = CreateParameter (f.FieldType.Resolve ()?.FullName ?? f.FieldType.FullName, null);
+			var field_parameter_type = f.FieldType.Resolve () ?? f.FieldType;
+			field.SetterParameter = CreateParameter (field_parameter_type.FullNameCorrected ().StripArity (), null);
 			field.SetterParameter.Name = "value";
 
 			return field;


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/pull/1266

While the issue described in https://github.com/dotnet/java-interop/pull/1266 is definitely an issue (types should not be added to the `generator` symbol table with a JNI type specification), that example was merely setting up the scenario needed to expose another bug.

When a JLO type has a `public` or `internal` field whose type is a nested type:

```csharp
namespace Com.Mypackage;

[Register ("com/mypackage/FieldClass")]
public class FieldClass : Java.Lang.Object
{
	public NestedFieldClass field;

	public class NestedFieldClass : Java.Lang.Object { }
}
```

We correctly import the `Field.TypeName` as `Com.Mypackage.FieldClass.NestedFieldClass`, however we also create `Field.SetterParameter` with the same type, but we do not replace the `/` nested type separator with a period, resulting in `Com.Mypackage.FieldClass/NestedFieldClass`.

Later, when validating the `Field`, we successfully find `Field.TypeName` in the symbol table, but fail to find `Field.SetterParameter` as the symbol table expects a period nested type separator. (Note this only happens because `NestedFieldClass` does not have a `[Register]` attribute, thus it gets added to the symbol table with its managed name rather than its Java name.)

This causes `generator` to crash with:

```
System.NotSupportedException: Unable to generate setter parameter list in method Bar in managed type Com.Example.Foo.
```

Fix this by applying the same `FullNameCorrected ()` logic that is applied to `Field.TypeName`.