### PR TITLE
[generator] Eliminate usage of `JNINativeWrapper.CreateDelegate` in bindings.

### DIFF
--- a/src/Java.Interop/Java.Interop/JniEnvironment.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.cs
@@ -57,17 +57,15 @@ namespace Java.Interop {
 			Justification = "Exceptions cannot cross a JNI boundary.")]
 		public static bool BeginMarshalMethod (IntPtr jnienv, out JniTransition transition, [NotNullWhen (true)] out JniRuntime? runtime)
 		{
-			JniEnvironmentInfo? env;
+			runtime = null;
 			Exception?          ex  = null;
 			try {
-				env     = Info.Value;
-				runtime = env.Runtime;
+				runtime = Info.Value?.Runtime;
 			}
 			catch (Exception e) {
 				ex  = e;
-				env = null;
 			}
-			if (env == null || runtime == null || ex != null) {
+			if (runtime == null || ex != null) {
 				transition  = default;
 				runtime     = null;
 				Console.Error.WriteLine ("JNI Environment Information is not available on this thread.");

--- a/src/Java.Interop/Java.Interop/JniEnvironment.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -48,6 +49,53 @@ namespace Java.Interop {
 			[MethodImpl (MethodImplOptions.AggressiveInlining)]
 			get {return CurrentInfo.WithinNewObjectScope;}
 			internal set {CurrentInfo.WithinNewObjectScope = value;}
+		}
+
+		[global::System.Diagnostics.CodeAnalysis.SuppressMessage (
+			"Design",
+			"CA1031:Do not catch general exception types",
+			Justification = "Exceptions cannot cross a JNI boundary.")]
+		public static bool BeginMarshalMethod (IntPtr jnienv, out JniTransition transition, [NotNullWhen (true)] out JniRuntime? runtime)
+		{
+			JniEnvironmentInfo? env;
+			Exception?          ex  = null;
+			try {
+				env = Info.Value;
+			}
+			catch (Exception e) {
+				ex  = e;
+				env = null;
+			}
+			if (env == null || env.runtime == null) {
+				transition  = default;
+				runtime     = null;
+				Console.Error.WriteLine ("JNI Environment Information is not available on this thread.");
+				if (ex != null) {
+					Console.Error.WriteLine (ex);
+				}
+				return false;
+			}
+
+			runtime     = env.runtime;
+
+			try {
+				runtime.OnEnterMarshalMethod ();
+				transition  = new JniTransition (jnienv);
+			}
+			catch (Exception e) {
+				runtime     = null;
+				transition  = default;
+
+				Console.Error.WriteLine ($"OnEnterMarshalMethod failed: {e}");
+				return false;
+			}
+
+			return true;
+		}
+
+		public static void EndMarshalMethod (ref JniTransition transition)
+		{
+			transition.Dispose ();
 		}
 
 		internal    static  void    SetEnvironmentPointer (IntPtr environmentPointer)
@@ -207,7 +255,7 @@ namespace Java.Interop {
 		IntPtr                  environmentPointer;
 		char[]?                 nameBuffer;
 		bool                    disposed;
-		JniRuntime?             runtime;
+		internal    JniRuntime? runtime;
 
 		public      int                     LocalReferenceCount     {get; internal set;}
 		public      bool                    WithinNewObjectScope    {get; set;}

--- a/src/Java.Interop/Java.Interop/JniEnvironment.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.cs
@@ -60,13 +60,14 @@ namespace Java.Interop {
 			JniEnvironmentInfo? env;
 			Exception?          ex  = null;
 			try {
-				env = Info.Value;
+				env     = Info.Value;
+				runtime = env.Runtime;
 			}
 			catch (Exception e) {
 				ex  = e;
 				env = null;
 			}
-			if (env == null || env.runtime == null) {
+			if (env == null || runtime == null || ex != null) {
 				transition  = default;
 				runtime     = null;
 				Console.Error.WriteLine ("JNI Environment Information is not available on this thread.");
@@ -75,8 +76,6 @@ namespace Java.Interop {
 				}
 				return false;
 			}
-
-			runtime     = env.runtime;
 
 			try {
 				runtime.OnEnterMarshalMethod ();
@@ -255,7 +254,7 @@ namespace Java.Interop {
 		IntPtr                  environmentPointer;
 		char[]?                 nameBuffer;
 		bool                    disposed;
-		internal    JniRuntime? runtime;
+		JniRuntime?             runtime;
 
 		public      int                     LocalReferenceCount     {get; internal set;}
 		public      bool                    WithinNewObjectScope    {get; set;}

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -437,6 +437,11 @@ namespace Java.Interop
 
 	partial class JniRuntime {
 
+		public virtual void OnEnterMarshalMethod ()
+		{
+			ValueManager.WaitForGCBridgeProcessing ();
+		}
+
 		public virtual void OnUserUnhandledException (ref JniTransition transition, Exception e)
 		{
 			transition.SetPendingException (e);

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -437,6 +437,14 @@ namespace Java.Interop
 
 	partial class JniRuntime {
 
+		public virtual void OnUserUnhandledException (ref JniTransition transition, Exception e)
+		{
+			transition.SetPendingException (e);
+
+			// TODO: Enable when we move to 'net9.0'
+			//Debugger.BreakForUserUnhandledException (e);
+		}
+
 		public virtual void RaisePendingException (Exception pendingException)
 		{
 			JniEnvironment.Exceptions.Throw (pendingException);

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-static Java.Interop.JniEnvironment.BeginMarshalMethod(nint jnienv, out Java.Interop.JniTransition transition, out Java.Interop.JniRuntime? runtime)
-static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransition transition);
+static Java.Interop.JniEnvironment.BeginMarshalMethod(nint jnienv, out Java.Interop.JniTransition transition, out Java.Interop.JniRuntime? runtime) -> bool
+static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransition transition) -> void
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+static Java.Interop.JniEnvironment.BeginMarshalMethod(nint jnienv, out Java.Interop.JniTransition transition, out Java.Interop.JniRuntime? runtime)
+static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransition transition);
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
+virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void

--- a/tests/generator-Tests/SupportFiles/DebuggerDisableUserUnhandledExceptionsAttribute.cs
+++ b/tests/generator-Tests/SupportFiles/DebuggerDisableUserUnhandledExceptionsAttribute.cs
@@ -1,0 +1,13 @@
+#if !NET9_0_OR_GREATER
+
+using System;
+
+namespace System.Diagnostics
+{
+	// This attribute was added in .NET 9, and we may not be targeting .NET 9 yet.
+	public class DebuggerDisableUserUnhandledExceptionsAttribute : Attribute
+	{
+	}
+}
+
+#endif  // !NET9_0_OR_GREATER

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -76,7 +76,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -111,7 +111,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -70,15 +70,23 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IHandler ()
 	{
-		if (cb_OnAnimationEnd_OnAnimationEnd_I_Z == null)
-			cb_OnAnimationEnd_OnAnimationEnd_I_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
-		return cb_OnAnimationEnd_OnAnimationEnd_I_Z;
+		return cb_OnAnimationEnd_OnAnimationEnd_I_Z ??= new _JniMarshal_PPI_Z (n_OnAnimationEnd_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.OnAnimationEnd (param1);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.OnAnimationEnd (param1);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -96,15 +104,23 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IIHandler ()
 	{
-		if (cb_OnAnimationEnd_OnAnimationEnd_II_Z == null)
-			cb_OnAnimationEnd_OnAnimationEnd_II_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
-		return cb_OnAnimationEnd_OnAnimationEnd_II_Z;
+		return cb_OnAnimationEnd_OnAnimationEnd_II_Z ??= new _JniMarshal_PPII_Z (n_OnAnimationEnd_II);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.OnAnimationEnd (param1, param2);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.OnAnimationEnd (param1, param2);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -76,18 +76,17 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -112,18 +111,17 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1, param2);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteDuplicateInterfaceEventArgs.txt
@@ -77,12 +77,14 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -111,12 +113,14 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1, param2);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -72,17 +72,16 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoSomething ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -73,12 +73,14 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoSomething ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -66,15 +66,22 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 #pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
-		if (cb_DoSomething_DoSomething_V == null)
-			cb_DoSomething_DoSomething_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
-		return cb_DoSomething_DoSomething_V;
+		return cb_DoSomething_DoSomething_V ??= new _JniMarshal_PP_V (n_DoSomething);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.DoSomething ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.DoSomething ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/Common/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -72,7 +72,7 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -59,7 +59,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -84,7 +84,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -132,7 +132,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -157,7 +157,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -232,7 +232,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -257,7 +257,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -291,7 +291,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -334,7 +334,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -382,7 +382,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -59,18 +59,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.Count;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -85,17 +84,16 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -134,18 +132,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -160,18 +157,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -236,18 +232,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -262,17 +257,16 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -297,11 +291,10 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
@@ -310,7 +303,7 @@ public partial class MyClass {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -341,18 +334,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -390,17 +382,16 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -60,12 +60,14 @@ public partial class MyClass {
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.Count;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -84,12 +86,14 @@ public partial class MyClass {
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -131,12 +135,14 @@ public partial class MyClass {
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -155,13 +161,15 @@ public partial class MyClass {
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -229,12 +237,14 @@ public partial class MyClass {
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -253,12 +263,14 @@ public partial class MyClass {
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -286,14 +298,16 @@ public partial class MyClass {
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
 			return __ret;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -328,12 +342,14 @@ public partial class MyClass {
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -375,12 +391,14 @@ public partial class MyClass {
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteClass.txt
@@ -53,15 +53,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count_get_Count_I == null)
-			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count_get_Count_I;
+		return cb_get_Count_get_Count_I ??= new _JniMarshal_PP_I (n_get_Count);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return __this.Count;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return __this.Count;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -69,15 +77,22 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_set_Count_I_V == null)
-			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_set_Count_I_V;
+		return cb_set_Count_set_Count_I_V ??= new _JniMarshal_PPI_V (n_set_Count_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		__this.Count = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			__this.Count = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -109,15 +124,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
-			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key_get_Key_Ljava_lang_String_;
+		return cb_get_Key_get_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_get_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return JNIEnv.NewString (__this.Key);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return JNIEnv.NewString (__this.Key);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -125,16 +148,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
-			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_set_Key_Ljava_lang_String__V;
+		return cb_set_Key_set_Key_Ljava_lang_String__V ??= new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
-		__this.Key = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Key = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -192,15 +222,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount_get_AbstractCount_I == null)
-			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount_get_AbstractCount_I;
+		return cb_get_AbstractCount_get_AbstractCount_I ??= new _JniMarshal_PP_I (n_get_AbstractCount);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return __this.AbstractCount;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return __this.AbstractCount;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -208,15 +246,22 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
-			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_set_AbstractCount_I_V;
+		return cb_set_AbstractCount_set_AbstractCount_I_V ??= new _JniMarshal_PPI_V (n_set_AbstractCount_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		__this.AbstractCount = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			__this.AbstractCount = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -234,17 +279,25 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
-			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I ??= new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
-		int __ret = __this.GetCountForKey (key);
-		return __ret;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+			int __ret = __this.GetCountForKey (key);
+			return __ret;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -268,15 +321,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key_Key_Ljava_lang_String_ == null)
-			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key_Key_Ljava_lang_String_;
+		return cb_Key_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return JNIEnv.NewString (__this.Key ());
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return JNIEnv.NewString (__this.Key ());
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -307,15 +368,22 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod_AbstractMethod_V == null)
-			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod_AbstractMethod_V;
+		return cb_AbstractMethod_AbstractMethod_V ??= new _JniMarshal_PP_V (n_AbstractMethod);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		__this.AbstractMethod ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			__this.AbstractMethod ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -140,7 +140,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -165,7 +165,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -206,7 +206,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -231,7 +231,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -275,7 +275,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -300,7 +300,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -341,7 +341,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -381,7 +381,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -414,7 +414,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -141,12 +141,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.Count;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -165,12 +167,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -205,12 +209,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -229,13 +235,15 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -272,12 +280,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -296,12 +306,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -336,14 +348,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
 			return __ret;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -375,12 +389,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -407,12 +423,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -140,18 +140,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.Count;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -166,17 +165,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -208,18 +206,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -234,18 +231,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -279,18 +275,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -305,17 +300,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -347,11 +341,10 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
@@ -360,7 +353,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -388,18 +381,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -422,17 +414,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteInterface.txt
@@ -134,15 +134,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count_get_Count_I == null)
-			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count_get_Count_I;
+		return cb_get_Count_get_Count_I ??= new _JniMarshal_PP_I (n_get_Count);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return __this.Count;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return __this.Count;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -150,15 +158,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_set_Count_I_V == null)
-			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_set_Count_I_V;
+		return cb_set_Count_set_Count_I_V ??= new _JniMarshal_PPI_V (n_set_Count_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		__this.Count = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			__this.Count = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -183,15 +198,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
-			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key_get_Key_Ljava_lang_String_;
+		return cb_get_Key_get_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_get_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return JNIEnv.NewString (__this.Key);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return JNIEnv.NewString (__this.Key);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -199,16 +222,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
-			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_set_Key_Ljava_lang_String__V;
+		return cb_set_Key_set_Key_Ljava_lang_String__V ??= new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
-		__this.Key = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Key = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -235,15 +265,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount_get_AbstractCount_I == null)
-			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount_get_AbstractCount_I;
+		return cb_get_AbstractCount_get_AbstractCount_I ??= new _JniMarshal_PP_I (n_get_AbstractCount);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return __this.AbstractCount;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return __this.AbstractCount;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -251,15 +289,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
-			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_set_AbstractCount_I_V;
+		return cb_set_AbstractCount_set_AbstractCount_I_V ??= new _JniMarshal_PPI_V (n_set_AbstractCount_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		__this.AbstractCount = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			__this.AbstractCount = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -284,17 +329,25 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
-			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I ??= new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
-		int __ret = __this.GetCountForKey (key);
-		return __ret;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+			int __ret = __this.GetCountForKey (key);
+			return __ret;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -315,15 +368,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key_Key_Ljava_lang_String_ == null)
-			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key_Key_Ljava_lang_String_;
+		return cb_Key_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		return JNIEnv.NewString (__this.Key ());
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			return JNIEnv.NewString (__this.Key ());
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -339,15 +400,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod_AbstractMethod_V == null)
-			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod_AbstractMethod_V;
+		return cb_AbstractMethod_AbstractMethod_V ??= new _JniMarshal_PP_V (n_AbstractMethod);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		__this.AbstractMethod ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			__this.AbstractMethod ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -39,11 +39,10 @@ public partial class MyClass : Java.Lang.Object {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var messages = (Java.Lang.ICharSequence[]?) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
 			IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
@@ -54,7 +53,7 @@ public partial class MyClass : Java.Lang.Object {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -39,7 +39,7 @@ public partial class MyClass : Java.Lang.Object {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -40,8 +40,10 @@ public partial class MyClass : Java.Lang.Object {
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
 			var messages = (Java.Lang.ICharSequence[]?) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
 			IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
@@ -49,7 +51,7 @@ public partial class MyClass : Java.Lang.Object {
 				JNIEnv.CopyArray (messages, native_messages);
 			return __ret;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1-NRT/WriteMethodWithCharSequenceArrays.txt
@@ -33,19 +33,27 @@ public partial class MyClass : Java.Lang.Object {
 #pragma warning disable 0169
 	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
 	{
-		if (cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ == null)
-			cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
-		return cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_;
+		return cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ ??= new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
-		var messages = (Java.Lang.ICharSequence[]?) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
-		IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
-		if (messages != null)
-			JNIEnv.CopyArray (messages, native_messages);
-		return __ret;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer)!;
+			var messages = (Java.Lang.ICharSequence[]?) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
+			IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
+			if (messages != null)
+				JNIEnv.CopyArray (messages, native_messages);
+			return __ret;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -59,7 +59,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -84,7 +84,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -132,7 +132,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -157,7 +157,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -232,7 +232,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -257,7 +257,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -291,7 +291,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -334,7 +334,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -382,7 +382,7 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -59,18 +59,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Count;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -85,17 +84,16 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -134,18 +132,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -160,18 +157,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -236,18 +232,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -262,17 +257,16 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -297,11 +291,10 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
@@ -310,7 +303,7 @@ public partial class MyClass {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -341,18 +334,17 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -390,17 +382,16 @@ public partial class MyClass {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -60,12 +60,14 @@ public partial class MyClass {
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Count;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -84,12 +86,14 @@ public partial class MyClass {
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -131,12 +135,14 @@ public partial class MyClass {
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -155,13 +161,15 @@ public partial class MyClass {
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -229,12 +237,14 @@ public partial class MyClass {
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -253,12 +263,14 @@ public partial class MyClass {
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -286,14 +298,16 @@ public partial class MyClass {
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
 			return __ret;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -328,12 +342,14 @@ public partial class MyClass {
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -375,12 +391,14 @@ public partial class MyClass {
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteClass.txt
@@ -53,15 +53,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count_get_Count_I == null)
-			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count_get_Count_I;
+		return cb_get_Count_get_Count_I ??= new _JniMarshal_PP_I (n_get_Count);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Count;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Count;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -69,15 +77,22 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_set_Count_I_V == null)
-			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_set_Count_I_V;
+		return cb_set_Count_set_Count_I_V ??= new _JniMarshal_PPI_V (n_set_Count_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.Count = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Count = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -109,15 +124,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
-			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key_get_Key_Ljava_lang_String_;
+		return cb_get_Key_get_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_get_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return JNIEnv.NewString (__this.Key);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Key);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -125,16 +148,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
-			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_set_Key_Ljava_lang_String__V;
+		return cb_set_Key_set_Key_Ljava_lang_String__V ??= new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
-		__this.Key = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Key = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -192,15 +222,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount_get_AbstractCount_I == null)
-			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount_get_AbstractCount_I;
+		return cb_get_AbstractCount_get_AbstractCount_I ??= new _JniMarshal_PP_I (n_get_AbstractCount);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.AbstractCount;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.AbstractCount;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -208,15 +246,22 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
-			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_set_AbstractCount_I_V;
+		return cb_set_AbstractCount_set_AbstractCount_I_V ??= new _JniMarshal_PPI_V (n_set_AbstractCount_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.AbstractCount = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.AbstractCount = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -234,17 +279,25 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
-			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I ??= new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
-		int __ret = __this.GetCountForKey (key);
-		return __ret;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+			int __ret = __this.GetCountForKey (key);
+			return __ret;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -268,15 +321,23 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key_Key_Ljava_lang_String_ == null)
-			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key_Key_Ljava_lang_String_;
+		return cb_Key_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return JNIEnv.NewString (__this.Key ());
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Key ());
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -307,15 +368,22 @@ public partial class MyClass {
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod_AbstractMethod_V == null)
-			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod_AbstractMethod_V;
+		return cb_AbstractMethod_AbstractMethod_V ??= new _JniMarshal_PP_V (n_AbstractMethod);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.AbstractMethod ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.AbstractMethod ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -11,15 +11,22 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 #pragma warning disable 0169
 	private static Delegate GetDoDefaultHandler ()
 	{
-		if (cb_DoDefault_DoDefault_V == null)
-			cb_DoDefault_DoDefault_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDefault));
-		return cb_DoDefault_DoDefault_V;
+		return cb_DoDefault_DoDefault_V ??= new _JniMarshal_PP_V (n_DoDefault);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.DoDefault ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.DoDefault ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -95,15 +102,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetDoDeclarationHandler ()
 	{
-		if (cb_DoDeclaration_DoDeclaration_V == null)
-			cb_DoDeclaration_DoDeclaration_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoDeclaration));
-		return cb_DoDeclaration_DoDeclaration_V;
+		return cb_DoDeclaration_DoDeclaration_V ??= new _JniMarshal_PP_V (n_DoDeclaration);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.DoDeclaration ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.DoDeclaration ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -17,7 +17,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -109,7 +109,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -17,17 +17,16 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoDefault ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -110,17 +109,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoDeclaration ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDefaultInterfaceMethodInvoker.txt
@@ -18,12 +18,14 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static void n_DoDefault (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoDefault ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -109,12 +111,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_DoDeclaration (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoDeclaration ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -76,7 +76,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -111,7 +111,7 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -70,15 +70,23 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IHandler ()
 	{
-		if (cb_OnAnimationEnd_OnAnimationEnd_I_Z == null)
-			cb_OnAnimationEnd_OnAnimationEnd_I_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_Z (n_OnAnimationEnd_I));
-		return cb_OnAnimationEnd_OnAnimationEnd_I_Z;
+		return cb_OnAnimationEnd_OnAnimationEnd_I_Z ??= new _JniMarshal_PPI_Z (n_OnAnimationEnd_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.OnAnimationEnd (param1);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.OnAnimationEnd (param1);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -96,15 +104,23 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 #pragma warning disable 0169
 	static Delegate GetOnAnimationEnd_IIHandler ()
 	{
-		if (cb_OnAnimationEnd_OnAnimationEnd_II_Z == null)
-			cb_OnAnimationEnd_OnAnimationEnd_II_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPII_Z (n_OnAnimationEnd_II));
-		return cb_OnAnimationEnd_OnAnimationEnd_II_Z;
+		return cb_OnAnimationEnd_OnAnimationEnd_II_Z ??= new _JniMarshal_PPII_Z (n_OnAnimationEnd_II);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.OnAnimationEnd (param1, param2);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.OnAnimationEnd (param1, param2);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -76,18 +76,17 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -112,18 +111,17 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1, param2);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteDuplicateInterfaceEventArgs.txt
@@ -77,12 +77,14 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	static bool n_OnAnimationEnd_I (IntPtr jnienv, IntPtr native__this, int param1)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -111,12 +113,14 @@ internal partial class AnimatorListenerInvoker : global::Java.Lang.Object, Anima
 	static bool n_OnAnimationEnd_II (IntPtr jnienv, IntPtr native__this, int param1, int param2)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.AnimatorListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.OnAnimationEnd (param1, param2);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -140,7 +140,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -165,7 +165,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -206,7 +206,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -231,7 +231,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -275,7 +275,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -300,7 +300,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {
@@ -341,7 +341,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -381,7 +381,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -414,7 +414,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -140,18 +140,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Count;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -166,17 +165,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -208,18 +206,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -234,18 +231,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -279,18 +275,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -305,17 +300,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -347,11 +341,10 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
@@ -360,7 +353,7 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -388,18 +381,17 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -422,17 +414,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -134,15 +134,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getget_CountHandler ()
 	{
-		if (cb_get_Count_get_Count_I == null)
-			cb_get_Count_get_Count_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Count));
-		return cb_get_Count_get_Count_I;
+		return cb_get_Count_get_Count_I ??= new _JniMarshal_PP_I (n_get_Count);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Count;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Count;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -150,15 +158,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getset_Count_IHandler ()
 	{
-		if (cb_set_Count_set_Count_I_V == null)
-			cb_set_Count_set_Count_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Count_I));
-		return cb_set_Count_set_Count_I_V;
+		return cb_set_Count_set_Count_I_V ??= new _JniMarshal_PPI_V (n_set_Count_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.Count = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Count = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -183,15 +198,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getget_KeyHandler ()
 	{
-		if (cb_get_Key_get_Key_Ljava_lang_String_ == null)
-			cb_get_Key_get_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_get_Key));
-		return cb_get_Key_get_Key_Ljava_lang_String_;
+		return cb_get_Key_get_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_get_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return JNIEnv.NewString (__this.Key);
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Key);
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -199,16 +222,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getset_Key_Ljava_lang_String_Handler ()
 	{
-		if (cb_set_Key_set_Key_Ljava_lang_String__V == null)
-			cb_set_Key_set_Key_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_));
-		return cb_set_Key_set_Key_Ljava_lang_String__V;
+		return cb_set_Key_set_Key_Ljava_lang_String__V ??= new _JniMarshal_PPL_V (n_set_Key_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
-		__this.Key = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
+			__this.Key = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -235,15 +265,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getget_AbstractCountHandler ()
 	{
-		if (cb_get_AbstractCount_get_AbstractCount_I == null)
-			cb_get_AbstractCount_get_AbstractCount_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_AbstractCount));
-		return cb_get_AbstractCount_get_AbstractCount_I;
+		return cb_get_AbstractCount_get_AbstractCount_I ??= new _JniMarshal_PP_I (n_get_AbstractCount);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.AbstractCount;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.AbstractCount;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -251,15 +289,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate Getset_AbstractCount_IHandler ()
 	{
-		if (cb_set_AbstractCount_set_AbstractCount_I_V == null)
-			cb_set_AbstractCount_set_AbstractCount_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_AbstractCount_I));
-		return cb_set_AbstractCount_set_AbstractCount_I_V;
+		return cb_set_AbstractCount_set_AbstractCount_I_V ??= new _JniMarshal_PPI_V (n_set_AbstractCount_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.AbstractCount = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.AbstractCount = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -284,17 +329,25 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetGetCountForKey_Ljava_lang_String_Handler ()
 	{
-		if (cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I == null)
-			cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_));
-		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I;
+		return cb_GetCountForKey_GetCountForKey_Ljava_lang_String__I ??= new _JniMarshal_PPL_I (n_GetCountForKey_Ljava_lang_String_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
-		int __ret = __this.GetCountForKey (key);
-		return __ret;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
+			int __ret = __this.GetCountForKey (key);
+			return __ret;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -315,15 +368,23 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetKeyHandler ()
 	{
-		if (cb_Key_Key_Ljava_lang_String_ == null)
-			cb_Key_Key_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_Key));
-		return cb_Key_Key_Ljava_lang_String_;
+		return cb_Key_Key_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_Key);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return JNIEnv.NewString (__this.Key ());
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return JNIEnv.NewString (__this.Key ());
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -339,15 +400,22 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 #pragma warning disable 0169
 	static Delegate GetAbstractMethodHandler ()
 	{
-		if (cb_AbstractMethod_AbstractMethod_V == null)
-			cb_AbstractMethod_AbstractMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_AbstractMethod));
-		return cb_AbstractMethod_AbstractMethod_V;
+		return cb_AbstractMethod_AbstractMethod_V ??= new _JniMarshal_PP_V (n_AbstractMethod);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.AbstractMethod ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.AbstractMethod ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterface.txt
@@ -141,12 +141,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static int n_get_Count (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Count;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -165,12 +167,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_set_Count_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Count = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -205,12 +209,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr n_get_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key);
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -229,13 +235,15 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_set_Key_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var value = JNIEnv.GetString (native_value, JniHandleOwnership.DoNotTransfer);
 			__this.Key = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -272,12 +280,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static int n_get_AbstractCount (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.AbstractCount;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -296,12 +306,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_set_AbstractCount_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractCount = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}
@@ -336,14 +348,16 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static int n_GetCountForKey_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_key)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var key = JNIEnv.GetString (native_key, JniHandleOwnership.DoNotTransfer);
 			int __ret = __this.GetCountForKey (key);
 			return __ret;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -375,12 +389,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static IntPtr n_Key (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return JNIEnv.NewString (__this.Key ());
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -407,12 +423,14 @@ internal partial class IMyInterfaceInvoker : global::Java.Lang.Object, IMyInterf
 	static void n_AbstractMethod (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.AbstractMethod ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -14,12 +14,14 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoSomething ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -7,15 +7,22 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 #pragma warning disable 0169
 	private static Delegate GetDoSomethingHandler ()
 	{
-		if (cb_DoSomething_DoSomething_V == null)
-			cb_DoSomething_DoSomething_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
-		return cb_DoSomething_DoSomething_V;
+		return cb_DoSomething_DoSomething_V ??= new _JniMarshal_PP_V (n_DoSomething);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.DoSomething ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.DoSomething ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -13,7 +13,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultMethod.txt
@@ -13,17 +13,16 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoSomething ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -13,7 +13,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -38,7 +38,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -14,12 +14,14 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -38,12 +40,14 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Value = value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -7,15 +7,23 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 #pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
-		if (cb_get_Value_get_Value_I == null)
-			cb_get_Value_get_Value_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
-		return cb_get_Value_get_Value_I;
+		return cb_get_Value_get_Value_I ??= new _JniMarshal_PP_I (n_get_Value);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -23,15 +31,22 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 #pragma warning disable 0169
 	private static Delegate Getset_Value_IHandler ()
 	{
-		if (cb_set_Value_set_Value_I_V == null)
-			cb_set_Value_set_Value_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_set_Value_I));
-		return cb_set_Value_set_Value_I_V;
+		return cb_set_Value_set_Value_I_V ??= new _JniMarshal_PPI_V (n_set_Value_I);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.Value = value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Value = value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultProperty.txt
@@ -13,18 +13,17 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -39,17 +38,16 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static void n_set_Value_I (IntPtr jnienv, IntPtr native__this, int value)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Value = value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -13,18 +13,17 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Value;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -14,12 +14,14 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Value;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -7,15 +7,23 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 #pragma warning disable 0169
 	private static Delegate Getget_ValueHandler ()
 	{
-		if (cb_get_Value_get_Value_I == null)
-			cb_get_Value_get_Value_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_get_Value));
-		return cb_get_Value_get_Value_I;
+		return cb_get_Value_get_Value_I ??= new _JniMarshal_PP_I (n_get_Value);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Value;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Value;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceDefaultPropertyGetterOnly.txt
@@ -13,7 +13,7 @@ public partial interface IMyInterface : IJavaObject, IJavaPeerable {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	private static int n_get_Value (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -72,17 +72,16 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoSomething ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -73,12 +73,14 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.DoSomething ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -66,15 +66,22 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 #pragma warning disable 0169
 	static Delegate GetDoSomethingHandler ()
 	{
-		if (cb_DoSomething_DoSomething_V == null)
-			cb_DoSomething_DoSomething_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_DoSomething));
-		return cb_DoSomething_DoSomething_V;
+		return cb_DoSomething_DoSomething_V ??= new _JniMarshal_PP_V (n_DoSomething);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.DoSomething ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<java.code.IMyInterface2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.DoSomething ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteInterfaceRedeclaredDefaultMethod.txt
@@ -72,7 +72,7 @@ internal partial class IMyInterface2Invoker : global::Java.Lang.Object, IMyInter
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_DoSomething (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -40,8 +40,10 @@ public partial class MyClass : Java.Lang.Object {
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var messages = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
 			IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
@@ -49,7 +51,7 @@ public partial class MyClass : Java.Lang.Object {
 				JNIEnv.CopyArray (messages, native_messages);
 			return __ret;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -39,7 +39,7 @@ public partial class MyClass : Java.Lang.Object {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -39,11 +39,10 @@ public partial class MyClass : Java.Lang.Object {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			var messages = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
 			IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
@@ -54,7 +53,7 @@ public partial class MyClass : Java.Lang.Object {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteMethodWithCharSequenceArrays.txt
@@ -33,19 +33,27 @@ public partial class MyClass : Java.Lang.Object {
 #pragma warning disable 0169
 	static Delegate GetEcho_arrayLjava_lang_CharSequence_Handler ()
 	{
-		if (cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ == null)
-			cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_));
-		return cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_;
+		return cb_echo_Echo_arrayLjava_lang_CharSequence__arrayLjava_lang_CharSequence_ ??= new _JniMarshal_PPL_L (n_Echo_arrayLjava_lang_CharSequence_);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static IntPtr n_Echo_arrayLjava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_messages)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		var messages = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
-		IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
-		if (messages != null)
-			JNIEnv.CopyArray (messages, native_messages);
-		return __ret;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Com.Example.MyClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			var messages = (Java.Lang.ICharSequence[]) JNIEnv.GetArray (native_messages, JniHandleOwnership.DoNotTransfer, typeof (Java.Lang.ICharSequence));
+			IntPtr __ret = JNIEnv.NewArray (__this.EchoFormatted (messages));
+			if (messages != null)
+				JNIEnv.CopyArray (messages, native_messages);
+			return __ret;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -108,12 +108,14 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -101,15 +101,23 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar_GetBar_I == null)
-			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar_GetBar_I;
+		return cb_getBar_GetBar_I ??= new _JniMarshal_PP_I (n_GetBar);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Bar;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Bar;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -107,18 +107,17 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceClass.txt
@@ -107,7 +107,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -84,12 +84,14 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Bar;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -176,12 +178,14 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -77,15 +77,23 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 #pragma warning disable 0169
 		static Delegate GetGetBarHandler ()
 		{
-			if (cb_getBar_GetBar_I == null)
-				cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-			return cb_getBar_GetBar_I;
+			return cb_getBar_GetBar_I ??= new _JniMarshal_PP_I (n_GetBar);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.Bar;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.Bar;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -161,15 +169,23 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar_GetBar_I == null)
-			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar_GetBar_I;
+		return cb_getBar_GetBar_I ??= new _JniMarshal_PP_I (n_GetBar);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Bar;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Bar;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -83,18 +83,17 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent.IChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Bar;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -177,18 +176,17 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteNestedInterfaceTypes.txt
@@ -83,7 +83,7 @@ public partial interface IParent : IJavaObject, IJavaPeerable {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -176,7 +176,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -74,7 +74,7 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {
@@ -176,7 +176,7 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return default;
 
 		try {

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -68,15 +68,23 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar_GetBar_I == null)
-			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar_GetBar_I;
+		return cb_getBar_GetBar_I ??= new _JniMarshal_PP_I (n_GetBar);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Bar;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Bar;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 
@@ -161,15 +169,23 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 #pragma warning disable 0169
 	static Delegate GetGetBarHandler ()
 	{
-		if (cb_getBar_GetBar_I == null)
-			cb_getBar_GetBar_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetBar));
-		return cb_getBar_GetBar_I;
+		return cb_getBar_GetBar_I ??= new _JniMarshal_PP_I (n_GetBar);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		return __this.Bar;
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			return __this.Bar;
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			return default;
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -74,18 +74,17 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169
@@ -177,18 +176,17 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return default;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorExpectedResults/XAJavaInterop1/WriteUnnestedInterfaceTypes.txt
@@ -75,12 +75,14 @@ internal partial class IParentChildInvoker : global::Java.Lang.Object, IParentCh
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParentChild> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();
@@ -176,12 +178,14 @@ internal partial class IParentInvoker : global::Java.Lang.Object, IParent {
 	static int n_GetBar (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<Com.Xamarin.Android.IParent> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			return __this.Bar;
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 			return default;
 		} finally {
 			__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -56,17 +56,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.BaseMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.BaseMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -50,15 +50,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetBaseMethodHandler ()
 		{
-			if (cb_baseMethod_BaseMethod_V == null)
-				cb_baseMethod_BaseMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
-			return cb_baseMethod_BaseMethod_V;
+			return cb_baseMethod_BaseMethod_V ??= new _JniMarshal_PP_V (n_BaseMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.BaseMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.BasePublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.BaseMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.BasePublicClass.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -73,17 +73,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Foo ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -67,15 +67,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetFooHandler ()
 		{
-			if (cb_foo_Foo_V == null)
-				cb_foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-			return cb_foo_Foo_V;
+			return cb_foo_Foo_V ??= new _JniMarshal_PP_V (n_Foo);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Foo ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Foo ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.ExtendPublicClass.cs
@@ -74,12 +74,14 @@ namespace Xamarin.Test {
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.ExtendPublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Foo ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -54,15 +54,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetExtendedMethodHandler ()
 		{
-			if (cb_extendedMethod_ExtendedMethod_V == null)
-				cb_extendedMethod_ExtendedMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_ExtendedMethod));
-			return cb_extendedMethod_ExtendedMethod_V;
+			return cb_extendedMethod_ExtendedMethod_V ??= new _JniMarshal_PP_V (n_ExtendedMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ExtendedMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.ExtendedMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.ExtendedMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -79,15 +86,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetBaseMethodHandler ()
 		{
-			if (cb_baseMethod_BaseMethod_V == null)
-				cb_baseMethod_BaseMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
-			return cb_baseMethod_BaseMethod_V;
+			return cb_baseMethod_BaseMethod_V ??= new _JniMarshal_PP_V (n_BaseMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.BaseMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.BaseMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -60,17 +60,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ExtendedMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.ExtendedMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -94,17 +93,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.BaseMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ExtendedMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -93,7 +93,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.IExtendedInterface.cs
@@ -61,12 +61,14 @@ namespace Xamarin.Test {
 		static void n_ExtendedMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.ExtendedMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -93,12 +95,14 @@ namespace Xamarin.Test {
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.IExtendedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.BaseMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -61,15 +61,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 			static Delegate GetFooHandler ()
 			{
-				if (cb_foo_Foo_V == null)
-					cb_foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-				return cb_foo_Foo_V;
+				return cb_foo_Foo_V ??= new _JniMarshal_PP_V (n_Foo);
 			}
 
+			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
 			{
-				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				__this.Foo ();
+				var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+				try {
+					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+					__this.Foo ();
+				} catch (global::System.Exception __e) {
+					global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				} finally {
+					__envp.Dispose ();
+				}
 			}
 #pragma warning restore 0169
 
@@ -133,15 +140,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetFooHandler ()
 		{
-			if (cb_foo_Foo_V == null)
-				cb_foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-			return cb_foo_Foo_V;
+			return cb_foo_Foo_V ??= new _JniMarshal_PP_V (n_Foo);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Foo ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Foo ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -67,17 +67,16 @@ namespace Xamarin.Test {
 			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
 			{
-				var __envp = new global::Java.Interop.JniTransition (jnienv);
-				var __r = global::Java.Interop.JniEnvironment.Runtime;
+				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+					return;
 
 				try {
-					__r.OnEnterMarshalMethod ();
 					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					__this.Foo ();
 				} catch (global::System.Exception __e) {
 					__r.OnUserUnhandledException (ref __envp, __e);
 				} finally {
-					__envp.Dispose ();
+					global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 				}
 			}
 #pragma warning restore 0169
@@ -148,17 +147,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Foo ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -68,12 +68,14 @@ namespace Xamarin.Test {
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
 			{
 				var __envp = new global::Java.Interop.JniTransition (jnienv);
+				var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 				try {
+					__r.OnEnterMarshalMethod ();
 					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass.IProtectedInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					__this.Foo ();
 				} catch (global::System.Exception __e) {
-					global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+					__r.OnUserUnhandledException (ref __envp, __e);
 				} finally {
 					__envp.Dispose ();
 				}
@@ -147,12 +149,14 @@ namespace Xamarin.Test {
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.PublicClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Foo ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.PublicClass.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Test {
 			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static void n_Foo (IntPtr jnienv, IntPtr native__this)
 			{
-				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 					return;
 
 				try {
@@ -147,7 +147,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Foo (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -73,17 +73,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.TestClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.BaseMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -67,15 +67,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetBaseMethodHandler ()
 		{
-			if (cb_baseMethod_BaseMethod_V == null)
-				cb_baseMethod_BaseMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_BaseMethod));
-			return cb_baseMethod_BaseMethod_V;
+			return cb_baseMethod_BaseMethod_V ??= new _JniMarshal_PP_V (n_BaseMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.TestClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.BaseMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.TestClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.BaseMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/Xamarin.Test.TestClass.cs
@@ -74,12 +74,14 @@ namespace Xamarin.Test {
 		static void n_BaseMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.TestClass> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.BaseMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.Adapter);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -81,13 +83,15 @@ namespace Xamarin.Test {
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
 				__this.Adapter = adapter;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -81,7 +81,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -56,18 +56,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.Adapter);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -82,18 +81,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
 				__this.Adapter = adapter;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AbsSpinner.cs
@@ -50,15 +50,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetAdapterHandler ()
 		{
-			if (cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_ == null)
-				cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
-			return cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_;
+			return cb_getAdapter_GetAdapter_Lxamarin_test_SpinnerAdapter_ ??= new _JniMarshal_PP_L (n_GetAdapter);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.Adapter);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.Adapter);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -66,16 +74,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetAdapter_Lxamarin_test_SpinnerAdapter_Handler ()
 		{
-			if (cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V == null)
-				cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_SpinnerAdapter_));
-			return cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V;
+			return cb_setAdapter_SetAdapter_Lxamarin_test_SpinnerAdapter__V ??= new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_SpinnerAdapter_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Lxamarin_test_SpinnerAdapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
-			__this.Adapter = adapter;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AbsSpinner> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var adapter = (global::Xamarin.Test.ISpinnerAdapter)global::Java.Lang.Object.GetObject<global::Xamarin.Test.ISpinnerAdapter> (native_adapter, JniHandleOwnership.DoNotTransfer);
+				__this.Adapter = adapter;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -82,7 +82,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -57,18 +57,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.RawAdapter);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -83,18 +82,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 				__this.RawAdapter = adapter;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -51,15 +51,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetAdapterHandler ()
 		{
-			if (cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_ == null)
-				cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetAdapter));
-			return cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_;
+			return cb_getAdapter_GetAdapter_Lxamarin_test_Adapter_ ??= new _JniMarshal_PP_L (n_GetAdapter);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.RawAdapter);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.RawAdapter);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -67,16 +75,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetAdapter_Lxamarin_test_Adapter_Handler ()
 		{
-			if (cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V == null)
-				cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_Adapter_));
-			return cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V;
+			return cb_setAdapter_SetAdapter_Lxamarin_test_Adapter__V ??= new _JniMarshal_PPL_V (n_SetAdapter_Lxamarin_test_Adapter_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
-			__this.RawAdapter = adapter;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
+				__this.RawAdapter = adapter;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.AdapterView.cs
@@ -58,12 +58,14 @@ namespace Xamarin.Test {
 		static IntPtr n_GetAdapter (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.RawAdapter);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -82,13 +84,15 @@ namespace Xamarin.Test {
 		static void n_SetAdapter_Lxamarin_test_Adapter_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.AdapterView> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 				__this.RawAdapter = adapter;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -56,18 +56,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.GenericReturn ());
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.GenericReturn ());
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/Xamarin.Test.GenericReturnObject.cs
@@ -50,15 +50,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGenericReturnHandler ()
 		{
-			if (cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_ == null)
-				cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GenericReturn));
-			return cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_;
+			return cb_GenericReturn_GenericReturn_Lxamarin_test_AdapterView_ ??= new _JniMarshal_PP_L (n_GenericReturn);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GenericReturn (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.GenericReturn ());
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.GenericReturnObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.GenericReturn ());
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -70,15 +70,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetSomeColorHandler ()
 		{
-			if (cb_getSomeColor_GetSomeColor_I == null)
-				cb_getSomeColor_GetSomeColor_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeColor));
-			return cb_getSomeColor_GetSomeColor_I;
+			return cb_getSomeColor_GetSomeColor_I ??= new _JniMarshal_PP_I (n_GetSomeColor);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.SomeColor.ToArgb ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.SomeColor.ToArgb ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -86,16 +94,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetSomeColor_IHandler ()
 		{
-			if (cb_setSomeColor_SetSomeColor_I_V == null)
-				cb_setSomeColor_SetSomeColor_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeColor_I));
-			return cb_setSomeColor_SetSomeColor_I_V;
+			return cb_setSomeColor_SetSomeColor_I_V ??= new _JniMarshal_PPI_V (n_SetSomeColor_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var newvalue = new global::Android.Graphics.Color (native_newvalue);
-			__this.SomeColor = newvalue;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var newvalue = new global::Android.Graphics.Color (native_newvalue);
+				__this.SomeColor = newvalue;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -101,7 +101,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -77,12 +77,14 @@ namespace Xamarin.Test {
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.SomeColor.ToArgb ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -101,13 +103,15 @@ namespace Xamarin.Test {
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var newvalue = new global::Android.Graphics.Color (native_newvalue);
 				__this.SomeColor = newvalue;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/Xamarin.Test.SomeObject.cs
@@ -76,18 +76,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSomeColor (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.SomeColor.ToArgb ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -102,18 +101,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeColor_I (IntPtr jnienv, IntPtr native__this, int native_newvalue)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var newvalue = new global::Android.Graphics.Color (native_newvalue);
 				__this.SomeColor = newvalue;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -28,15 +28,23 @@ namespace Java.Lang {
 #pragma warning disable 0169
 		static Delegate GetGetMessageHandler ()
 		{
-			if (cb_getMessage_GetMessage_Ljava_lang_String_ == null)
-				cb_getMessage_GetMessage_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
-			return cb_getMessage_GetMessage_Ljava_lang_String_;
+			return cb_getMessage_GetMessage_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_GetMessage);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewString (__this.Message);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewString (__this.Message);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -35,12 +35,14 @@ namespace Java.Lang {
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.Message);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -34,7 +34,7 @@ namespace Java.Lang {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Java.Lang.Throwable.cs
@@ -34,18 +34,17 @@ namespace Java.Lang {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.Message);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.UsePartial (partial));
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -56,18 +56,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.UsePartial (partial));
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/Xamarin.Test.CSharpKeywords.cs
@@ -50,15 +50,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetUsePartial_IHandler ()
 		{
-			if (cb_usePartial_UsePartial_I_Ljava_lang_String_ == null)
-				cb_usePartial_UsePartial_I_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_UsePartial_I));
-			return cb_usePartial_UsePartial_I_Ljava_lang_String_;
+			return cb_usePartial_UsePartial_I_Ljava_lang_String_ ??= new _JniMarshal_PPI_L (n_UsePartial_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_UsePartial_I (IntPtr jnienv, IntPtr native__this, int partial)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewString (__this.UsePartial (partial));
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.CSharpKeywords> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewString (__this.UsePartial (partial));
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -46,17 +46,25 @@ namespace Android.Text {
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
-				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
-			int __ret = (int) __this.GetSpanFlags (tag);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+				int __ret = (int) __this.GetSpanFlags (tag);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -52,7 +52,7 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -52,11 +52,10 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (tag);
@@ -65,7 +64,7 @@ namespace Android.Text {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpannable.cs
@@ -53,14 +53,16 @@ namespace Android.Text {
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpannable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (tag);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -56,14 +56,16 @@ namespace Android.Text {
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (tag);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -55,11 +55,10 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (tag);
@@ -68,7 +67,7 @@ namespace Android.Text {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -49,17 +49,25 @@ namespace Android.Text {
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
-				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
-			int __ret = (int) __this.GetSpanFlags (tag);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.ISpanned> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+				int __ret = (int) __this.GetSpanFlags (tag);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.ISpanned.cs
@@ -55,7 +55,7 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -100,14 +100,16 @@ namespace Android.Text {
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var what = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (what);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -99,7 +99,7 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -99,11 +99,10 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var what = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (what);
@@ -112,7 +111,7 @@ namespace Android.Text {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableString.cs
@@ -93,17 +93,25 @@ namespace Android.Text {
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
-				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_what)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var what = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
-			int __ret = (int) __this.GetSpanFlags (what);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableString> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var what = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_what, JniHandleOwnership.DoNotTransfer);
+				int __ret = (int) __this.GetSpanFlags (what);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -57,14 +57,16 @@ namespace Android.Text {
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (p0);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -50,17 +50,25 @@ namespace Android.Text {
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
-				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
-			int __ret = (int) __this.GetSpanFlags (p0);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
+				int __ret = (int) __this.GetSpanFlags (p0);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -56,7 +56,7 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Text.SpannableStringInternal.cs
@@ -56,11 +56,10 @@ namespace Android.Text {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Text.SpannableStringInternal> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_p0, JniHandleOwnership.DoNotTransfer);
 				int __ret = (int) __this.GetSpanFlags (p0);
@@ -69,7 +68,7 @@ namespace Android.Text {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -61,16 +61,23 @@ namespace Android.Views {
 #pragma warning disable 0169
 			static Delegate GetOnClick_Landroid_view_View_Handler ()
 			{
-				if (cb_onClick_OnClick_Landroid_view_View__V == null)
-					cb_onClick_OnClick_Landroid_view_View__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_OnClick_Landroid_view_View_));
-				return cb_onClick_OnClick_Landroid_view_View__V;
+				return cb_onClick_OnClick_Landroid_view_View__V ??= new _JniMarshal_PPL_V (n_OnClick_Landroid_view_View_);
 			}
 
+			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
 			{
-				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				var v = global::Java.Lang.Object.GetObject<global::Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
-				__this.OnClick (v);
+				var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+				try {
+					var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+					var v = global::Java.Lang.Object.GetObject<global::Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
+					__this.OnClick (v);
+				} catch (global::System.Exception __e) {
+					global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				} finally {
+					__envp.Dispose ();
+				}
 			}
 #pragma warning restore 0169
 
@@ -150,16 +157,23 @@ namespace Android.Views {
 #pragma warning disable 0169
 		static Delegate GetSetOnClickListener_Landroid_view_View_OnClickListener_Handler ()
 		{
-			if (cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V == null)
-				cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnClickListener_Landroid_view_View_OnClickListener_));
-			return cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V;
+			return cb_setOnClickListener_SetOnClickListener_Landroid_view_View_OnClickListener__V ??= new _JniMarshal_PPL_V (n_SetOnClickListener_Landroid_view_View_OnClickListener_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
-			__this.SetOnClickListener (l);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
+				__this.SetOnClickListener (l);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -181,16 +195,23 @@ namespace Android.Views {
 #pragma warning disable 0169
 		static Delegate GetSetOn123Listener_Landroid_view_View_OnClickListener_Handler ()
 		{
-			if (cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V == null)
-				cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOn123Listener_Landroid_view_View_OnClickListener_));
-			return cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V;
+			return cb_setOn123Listener_SetOn123Listener_Landroid_view_View_OnClickListener__V ??= new _JniMarshal_PPL_V (n_SetOn123Listener_Landroid_view_View_OnClickListener_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
-			__this.SetOn123Listener (l);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
+				__this.SetOn123Listener (l);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -212,16 +233,23 @@ namespace Android.Views {
 #pragma warning disable 0169
 		static Delegate GetAddTouchables_Ljava_util_ArrayList_Handler ()
 		{
-			if (cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V == null)
-				cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_AddTouchables_Ljava_util_ArrayList_));
-			return cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V;
+			return cb_addTouchables_AddTouchables_Ljava_util_ArrayList__V ??= new _JniMarshal_PPL_V (n_AddTouchables_Ljava_util_ArrayList_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var views = global::Android.Runtime.JavaList<global::Android.Views.View>.FromJniHandle (native_views, JniHandleOwnership.DoNotTransfer);
-			__this.AddTouchables (views);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var views = global::Android.Runtime.JavaList<global::Android.Views.View>.FromJniHandle (native_views, JniHandleOwnership.DoNotTransfer);
+				__this.AddTouchables (views);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -68,13 +68,15 @@ namespace Android.Views {
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
 			{
 				var __envp = new global::Java.Interop.JniTransition (jnienv);
+				var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 				try {
+					__r.OnEnterMarshalMethod ();
 					var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					var v = global::Java.Lang.Object.GetObject<global::Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
 					__this.OnClick (v);
 				} catch (global::System.Exception __e) {
-					global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+					__r.OnUserUnhandledException (ref __envp, __e);
 				} finally {
 					__envp.Dispose ();
 				}
@@ -164,13 +166,15 @@ namespace Android.Views {
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 				__this.SetOnClickListener (l);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -202,13 +206,15 @@ namespace Android.Views {
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 				__this.SetOn123Listener (l);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -240,13 +246,15 @@ namespace Android.Views {
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var views = global::Android.Runtime.JavaList<global::Android.Views.View>.FromJniHandle (native_views, JniHandleOwnership.DoNotTransfer);
 				__this.AddTouchables (views);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -67,18 +67,17 @@ namespace Android.Views {
 			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
 			{
-				var __envp = new global::Java.Interop.JniTransition (jnienv);
-				var __r = global::Java.Interop.JniEnvironment.Runtime;
+				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+					return;
 
 				try {
-					__r.OnEnterMarshalMethod ();
 					var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					var v = global::Java.Lang.Object.GetObject<global::Android.Views.View> (native_v, JniHandleOwnership.DoNotTransfer);
 					__this.OnClick (v);
 				} catch (global::System.Exception __e) {
 					__r.OnUserUnhandledException (ref __envp, __e);
 				} finally {
-					__envp.Dispose ();
+					global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 				}
 			}
 #pragma warning restore 0169
@@ -165,18 +164,17 @@ namespace Android.Views {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 				__this.SetOnClickListener (l);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -205,18 +203,17 @@ namespace Android.Views {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var l = (global::Android.Views.View.IOnClickListener)global::Java.Lang.Object.GetObject<global::Android.Views.View.IOnClickListener> (native_l, JniHandleOwnership.DoNotTransfer);
 				__this.SetOn123Listener (l);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -245,18 +242,17 @@ namespace Android.Views {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Android.Views.View> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var views = global::Android.Runtime.JavaList<global::Android.Views.View>.FromJniHandle (native_views, JniHandleOwnership.DoNotTransfer);
 				__this.AddTouchables (views);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/Android.Views.View.cs
@@ -67,7 +67,7 @@ namespace Android.Views {
 			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static void n_OnClick_Landroid_view_View_ (IntPtr jnienv, IntPtr native__this, IntPtr native_v)
 			{
-				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 					return;
 
 				try {
@@ -164,7 +164,7 @@ namespace Android.Views {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOnClickListener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -203,7 +203,7 @@ namespace Android.Views {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOn123Listener_Landroid_view_View_OnClickListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_l)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -242,7 +242,7 @@ namespace Android.Views {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_AddTouchables_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_views)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -54,7 +54,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_RequiresSecureDecoderComponent_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -54,11 +54,10 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_RequiresSecureDecoderComponent_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = JNIEnv.GetString (native_p0, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.RequiresSecureDecoderComponent (p0);
@@ -67,7 +66,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -55,14 +55,16 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static bool n_RequiresSecureDecoderComponent_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = JNIEnv.GetString (native_p0, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.RequiresSecureDecoderComponent (p0);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto.cs
@@ -48,17 +48,25 @@ namespace Com.Google.Android.Exoplayer.Drm {
 #pragma warning disable 0169
 		static Delegate GetRequiresSecureDecoderComponent_Ljava_lang_String_Handler ()
 		{
-			if (cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z == null)
-				cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_RequiresSecureDecoderComponent_Ljava_lang_String_));
-			return cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z;
+			return cb_requiresSecureDecoderComponent_RequiresSecureDecoderComponent_Ljava_lang_String__Z ??= new _JniMarshal_PPL_Z (n_RequiresSecureDecoderComponent_Ljava_lang_String_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_RequiresSecureDecoderComponent_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = JNIEnv.GetString (native_p0, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.RequiresSecureDecoderComponent (p0);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaCrypto> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var p0 = JNIEnv.GetString (native_p0, JniHandleOwnership.DoNotTransfer);
+				bool __ret = __this.RequiresSecureDecoderComponent (p0);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -56,8 +56,10 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
 				var p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
@@ -68,7 +70,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 				if (p4 != null)
 					JNIEnv.CopyArray (p4, native_p4);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -233,13 +235,15 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
 				__this.SetOnEventListener (p0);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -55,7 +55,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -233,7 +233,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -55,11 +55,10 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
 				var p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
@@ -72,7 +71,7 @@ namespace Com.Google.Android.Exoplayer.Drm {
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -234,18 +233,17 @@ namespace Com.Google.Android.Exoplayer.Drm {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
 				__this.SetOnEventListener (p0);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/Com.Google.Android.Exoplayer.Drm.IExoMediaDrm.cs
@@ -49,22 +49,29 @@ namespace Com.Google.Android.Exoplayer.Drm {
 #pragma warning disable 0169
 		static Delegate GetOnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayBHandler ()
 		{
-			if (cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V == null)
-				cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLLIIL_V (n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB));
-			return cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V;
+			return cb_onEvent_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB_V ??= new _JniMarshal_PPLLIIL_V (n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_OnEvent_Lcom_google_android_exoplayer_drm_ExoMediaDrm_arrayBIIarrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_p0, IntPtr native_p1, int p2, int p3, IntPtr native_p4)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
-			var p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			var p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			__this.OnEvent (p0, p1, p2, p3, p4);
-			if (p1 != null)
-				JNIEnv.CopyArray (p1, native_p1);
-			if (p4 != null)
-				JNIEnv.CopyArray (p4, native_p4);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (native_p0, JniHandleOwnership.DoNotTransfer);
+				var p1 = (byte[]) JNIEnv.GetArray (native_p1, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				var p4 = (byte[]) JNIEnv.GetArray (native_p4, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				__this.OnEvent (p0, p1, p2, p3, p4);
+				if (p1 != null)
+					JNIEnv.CopyArray (p1, native_p1);
+				if (p4 != null)
+					JNIEnv.CopyArray (p4, native_p4);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -219,16 +226,23 @@ namespace Com.Google.Android.Exoplayer.Drm {
 #pragma warning disable 0169
 		static Delegate GetSetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_Handler ()
 		{
-			if (cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V == null)
-				cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_));
-			return cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V;
+			return cb_setOnEventListener_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener__V ??= new _JniMarshal_PPL_V (n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetOnEventListener_Lcom_google_android_exoplayer_drm_ExoMediaDrm_OnEventListener_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
-			__this.SetOnEventListener (p0);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrm> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var p0 = (global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener)global::Java.Lang.Object.GetObject<global::Com.Google.Android.Exoplayer.Drm.IExoMediaDrmOnEventListener> (native_p0, JniHandleOwnership.DoNotTransfer);
+				__this.SetOnEventListener (p0);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -54,17 +54,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -55,12 +55,14 @@ namespace Xamarin.Test {
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II1.cs
@@ -48,15 +48,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close_Close_V == null)
-				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close_Close_V;
+			return cb_close_Close_V ??= new _JniMarshal_PP_V (n_Close);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Close ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II1> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Close ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -54,17 +54,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -48,15 +48,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close_Close_V == null)
-				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close_Close_V;
+			return cb_close_Close_V ??= new _JniMarshal_PP_V (n_Close);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Close ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Close ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -55,12 +55,14 @@ namespace Xamarin.Test {
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.II2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.II2.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -50,15 +50,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close_Close_V == null)
-				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close_Close_V;
+			return cb_close_Close_V ??= new _JniMarshal_PP_V (n_Close);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Close ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Close ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject.cs
@@ -56,17 +56,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -50,15 +50,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetIrrelevantHandler ()
 		{
-			if (cb_irrelevant_Irrelevant_V == null)
-				cb_irrelevant_Irrelevant_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Irrelevant));
-			return cb_irrelevant_Irrelevant_V;
+			return cb_irrelevant_Irrelevant_V ??= new _JniMarshal_PP_V (n_Irrelevant);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Irrelevant ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Irrelevant ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -77,15 +84,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close_Close_V == null)
-				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close_Close_V;
+			return cb_close_Close_V ??= new _JniMarshal_PP_V (n_Close);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Close ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Close ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -91,7 +91,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Irrelevant ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -91,12 +93,14 @@ namespace Xamarin.Test {
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/Xamarin.Test.SomeObject2.cs
@@ -56,17 +56,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Irrelevant (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Irrelevant ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -92,17 +91,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject2> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -70,18 +70,17 @@ namespace Xamarin.Test {
 				[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)
 				{
-					var __envp = new global::Java.Interop.JniTransition (jnienv);
-					var __r = global::Java.Interop.JniEnvironment.Runtime;
+					if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+						return default;
 
 					try {
-						__r.OnEnterMarshalMethod ();
 						var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 						return JNIEnv.ToLocalJniHandle (__this.Build (p0));
 					} catch (global::System.Exception __e) {
 						__r.OnUserUnhandledException (ref __envp, __e);
 						return default;
 					} finally {
-						__envp.Dispose ();
+						global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 					}
 				}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -64,15 +64,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 				static Delegate GetBuild_IHandler ()
 				{
-					if (cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_ == null)
-						cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_Build_I));
-					return cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_;
+					return cb_build_Build_I_Lxamarin_test_NotificationCompatBase_Action_ ??= new _JniMarshal_PPI_L (n_Build_I);
 				}
 
+				[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)
 				{
-					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-					return JNIEnv.ToLocalJniHandle (__this.Build (p0));
+					var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+					try {
+						var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+						return JNIEnv.ToLocalJniHandle (__this.Build (p0));
+					} catch (global::System.Exception __e) {
+						global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+						return default;
+					} finally {
+						__envp.Dispose ();
+					}
 				}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -71,12 +71,14 @@ namespace Xamarin.Test {
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)
 				{
 					var __envp = new global::Java.Interop.JniTransition (jnienv);
+					var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 					try {
+						__r.OnEnterMarshalMethod ();
 						var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.NotificationCompatBase.Action.IFactory> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 						return JNIEnv.ToLocalJniHandle (__this.Build (p0));
 					} catch (global::System.Exception __e) {
-						global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+						__r.OnUserUnhandledException (ref __envp, __e);
 						return default;
 					} finally {
 						__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/Xamarin.Test.NotificationCompatBase.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Test {
 				[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 				static IntPtr n_Build_I (IntPtr jnienv, IntPtr native__this, int p0)
 				{
-					if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+					if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 						return default;
 
 					try {

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Test {
 			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 			{
-				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 					return default;
 
 				try {
@@ -129,7 +129,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -61,12 +61,14 @@ namespace Xamarin.Test {
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 			{
 				var __envp = new global::Java.Interop.JniTransition (jnienv);
+				var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 				try {
+					__r.OnEnterMarshalMethod ();
 					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 				} catch (global::System.Exception __e) {
-					global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+					__r.OnUserUnhandledException (ref __envp, __e);
 					return default;
 				} finally {
 					__envp.Dispose ();
@@ -129,12 +131,14 @@ namespace Xamarin.Test {
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.GetHandle ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -54,15 +54,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 			static Delegate GetSetCustomDimension_IHandler ()
 			{
-				if (cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_ == null)
-					cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
-				return cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_;
+				return cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_A_B_ ??= new _JniMarshal_PPI_L (n_SetCustomDimension_I);
 			}
 
+			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 			{
-				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-				return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
+				var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+				try {
+					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+					return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
+				} catch (global::System.Exception __e) {
+					global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+					return default;
+				} finally {
+					__envp.Dispose ();
+				}
 			}
 #pragma warning restore 0169
 
@@ -114,15 +122,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetHandleHandler ()
 		{
-			if (cb_getHandle_GetHandle_I == null)
-				cb_getHandle_GetHandle_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetHandle));
-			return cb_getHandle_GetHandle_I;
+			return cb_getHandle_GetHandle_I ??= new _JniMarshal_PP_I (n_GetHandle);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.GetHandle ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.GetHandle ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.A.cs
@@ -60,18 +60,17 @@ namespace Xamarin.Test {
 			[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 			static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 			{
-				var __envp = new global::Java.Interop.JniTransition (jnienv);
-				var __r = global::Java.Interop.JniEnvironment.Runtime;
+				if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+					return default;
 
 				try {
-					__r.OnEnterMarshalMethod ();
 					var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A.B> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 					return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 				} catch (global::System.Exception __e) {
 					__r.OnUserUnhandledException (ref __envp, __e);
 					return default;
 				} finally {
-					__envp.Dispose ();
+					global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 				}
 			}
 #pragma warning restore 0169
@@ -130,18 +129,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetHandle (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.GetHandle ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -51,15 +51,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetCustomDimension_IHandler ()
 		{
-			if (cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_ == null)
-				cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_L (n_SetCustomDimension_I));
-			return cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_;
+			return cb_setCustomDimension_SetCustomDimension_I_Lxamarin_test_C_ ??= new _JniMarshal_PPI_L (n_SetCustomDimension_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -57,18 +57,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.C.cs
@@ -58,12 +58,14 @@ namespace Xamarin.Test {
 		static IntPtr n_SetCustomDimension_I (IntPtr jnienv, IntPtr native__this, int index)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.C> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.SetCustomDimension (index));
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -113,7 +113,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -158,7 +158,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -195,7 +195,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -230,7 +230,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -267,7 +267,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -304,7 +304,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -350,7 +350,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -388,7 +388,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -77,12 +77,14 @@ namespace Xamarin.Test {
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewArray (__this.GetType ());
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -113,15 +115,17 @@ namespace Xamarin.Test {
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
 				var t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.Handle (o, t);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -157,12 +161,14 @@ namespace Xamarin.Test {
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.IntegerMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -193,12 +199,14 @@ namespace Xamarin.Test {
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.VoidMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -227,12 +235,14 @@ namespace Xamarin.Test {
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.StringMethod ());
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -263,12 +273,14 @@ namespace Xamarin.Test {
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.ObjectMethod ());
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -299,14 +311,16 @@ namespace Xamarin.Test {
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
 				var anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
 				__this.VoidMethodWithParams (astring, anint, anObject);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -344,12 +358,14 @@ namespace Xamarin.Test {
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.ObsoleteMethod ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -381,13 +397,15 @@ namespace Xamarin.Test {
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 				__this.ArrayListTest (p0);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -70,15 +70,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetTypeHandler ()
 		{
-			if (cb_getType_GetType_arrayI == null)
-				cb_getType_GetType_arrayI = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetType));
-			return cb_getType_GetType_arrayI;
+			return cb_getType_GetType_arrayI ??= new _JniMarshal_PP_L (n_GetType);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewArray (__this.GetType ());
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewArray (__this.GetType ());
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -98,18 +106,26 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetHandle_Ljava_lang_Object_Ljava_lang_Throwable_Handler ()
 		{
-			if (cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I == null)
-				cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLL_I (n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_));
-			return cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I;
+			return cb_handle_Handle_Ljava_lang_Object_Ljava_lang_Throwable__I ??= new _JniMarshal_PPLL_I (n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
-			var t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
-			int __ret = __this.Handle (o, t);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
+				var t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
+				int __ret = __this.Handle (o, t);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -134,15 +150,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetIntegerMethodHandler ()
 		{
-			if (cb_IntegerMethod_IntegerMethod_I == null)
-				cb_IntegerMethod_IntegerMethod_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_IntegerMethod));
-			return cb_IntegerMethod_IntegerMethod_I;
+			return cb_IntegerMethod_IntegerMethod_I ??= new _JniMarshal_PP_I (n_IntegerMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.IntegerMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.IntegerMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -162,15 +186,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetVoidMethodHandler ()
 		{
-			if (cb_VoidMethod_VoidMethod_V == null)
-				cb_VoidMethod_VoidMethod_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_VoidMethod));
-			return cb_VoidMethod_VoidMethod_V;
+			return cb_VoidMethod_VoidMethod_V ??= new _JniMarshal_PP_V (n_VoidMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.VoidMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.VoidMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -189,15 +220,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetStringMethodHandler ()
 		{
-			if (cb_StringMethod_StringMethod_Ljava_lang_String_ == null)
-				cb_StringMethod_StringMethod_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_StringMethod));
-			return cb_StringMethod_StringMethod_Ljava_lang_String_;
+			return cb_StringMethod_StringMethod_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_StringMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewString (__this.StringMethod ());
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewString (__this.StringMethod ());
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -217,15 +256,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetObjectMethodHandler ()
 		{
-			if (cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_ == null)
-				cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_ObjectMethod));
-			return cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_;
+			return cb_ObjectMethod_ObjectMethod_Ljava_lang_Object_ ??= new _JniMarshal_PP_L (n_ObjectMethod);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.ObjectMethod ());
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.ObjectMethod ());
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -245,17 +292,24 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetVoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_Handler ()
 		{
-			if (cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V == null)
-				cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLIL_V (n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_));
-			return cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V;
+			return cb_VoidMethodWithParams_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object__V ??= new _JniMarshal_PPLIL_V (n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
-			var anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
-			__this.VoidMethodWithParams (astring, anint, anObject);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
+				var anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
+				__this.VoidMethodWithParams (astring, anint, anObject);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -282,16 +336,24 @@ namespace Xamarin.Test {
 		[global::System.Obsolete]
 		static Delegate GetObsoleteMethodHandler ()
 		{
-			if (cb_ObsoleteMethod_ObsoleteMethod_I == null)
-				cb_ObsoleteMethod_ObsoleteMethod_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_ObsoleteMethod));
-			return cb_ObsoleteMethod_ObsoleteMethod_I;
+			return cb_ObsoleteMethod_ObsoleteMethod_I ??= new _JniMarshal_PP_I (n_ObsoleteMethod);
 		}
 
 		[global::System.Obsolete]
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.ObsoleteMethod ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.ObsoleteMethod ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -312,16 +374,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetArrayListTest_Ljava_util_ArrayList_Handler ()
 		{
-			if (cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V == null)
-				cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ArrayListTest_Ljava_util_ArrayList_));
-			return cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V;
+			return cb_ArrayListTest_ArrayListTest_Ljava_util_ArrayList__V ??= new _JniMarshal_PPL_V (n_ArrayListTest_Ljava_util_ArrayList_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
-			__this.ArrayListTest (p0);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
+				__this.ArrayListTest (p0);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/Xamarin.Test.SomeObject.cs
@@ -76,18 +76,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetType (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewArray (__this.GetType ());
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -114,11 +113,10 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Handle_Ljava_lang_Object_Ljava_lang_Throwable_ (IntPtr jnienv, IntPtr native__this, IntPtr native_o, IntPtr native_t)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var o = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_o, JniHandleOwnership.DoNotTransfer);
 				var t = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (native_t, JniHandleOwnership.DoNotTransfer);
@@ -128,7 +126,7 @@ namespace Xamarin.Test {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -160,18 +158,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_IntegerMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.IntegerMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -198,17 +195,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_VoidMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.VoidMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -234,18 +230,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_StringMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.StringMethod ());
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -272,18 +267,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_ObjectMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.ObjectMethod ());
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -310,11 +304,10 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_VoidMethodWithParams_Ljava_lang_String_ILjava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_astring, int anint, IntPtr native_anObject)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var astring = JNIEnv.GetString (native_astring, JniHandleOwnership.DoNotTransfer);
 				var anObject = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_anObject, JniHandleOwnership.DoNotTransfer);
@@ -322,7 +315,7 @@ namespace Xamarin.Test {
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -357,18 +350,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_ObsoleteMethod (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.ObsoleteMethod ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -396,18 +388,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ArrayListTest_Ljava_util_ArrayList_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 				__this.ArrayListTest (p0);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -56,18 +56,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.SomeInteger;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -82,17 +81,16 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.SomeInteger = newvalue;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -117,18 +115,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.SomeObjectProperty);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -143,18 +140,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
 				__this.SomeObjectProperty = newvalue;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -179,18 +175,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.SomeString);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -205,18 +200,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
 				__this.SomeString = newvalue;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -81,7 +81,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -115,7 +115,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -140,7 +140,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -175,7 +175,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -200,7 +200,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -57,12 +57,14 @@ namespace Xamarin.Test {
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.SomeInteger;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -81,12 +83,14 @@ namespace Xamarin.Test {
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.SomeInteger = newvalue;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -114,12 +118,14 @@ namespace Xamarin.Test {
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.SomeObjectProperty);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -138,13 +144,15 @@ namespace Xamarin.Test {
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
 				__this.SomeObjectProperty = newvalue;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -172,12 +180,14 @@ namespace Xamarin.Test {
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.SomeString);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -196,13 +206,15 @@ namespace Xamarin.Test {
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
 				__this.SomeString = newvalue;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/Xamarin.Test.SomeObject.cs
@@ -50,15 +50,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetSomeIntegerHandler ()
 		{
-			if (cb_getSomeInteger_GetSomeInteger_I == null)
-				cb_getSomeInteger_GetSomeInteger_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_GetSomeInteger));
-			return cb_getSomeInteger_GetSomeInteger_I;
+			return cb_getSomeInteger_GetSomeInteger_I ??= new _JniMarshal_PP_I (n_GetSomeInteger);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSomeInteger (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.SomeInteger;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.SomeInteger;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -66,15 +74,22 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetSomeInteger_IHandler ()
 		{
-			if (cb_setSomeInteger_SetSomeInteger_I_V == null)
-				cb_setSomeInteger_SetSomeInteger_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_SetSomeInteger_I));
-			return cb_setSomeInteger_SetSomeInteger_I_V;
+			return cb_setSomeInteger_SetSomeInteger_I_V ??= new _JniMarshal_PPI_V (n_SetSomeInteger_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeInteger_I (IntPtr jnienv, IntPtr native__this, int newvalue)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.SomeInteger = newvalue;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.SomeInteger = newvalue;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -92,15 +107,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetSomeObjectPropertyHandler ()
 		{
-			if (cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_ == null)
-				cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeObjectProperty));
-			return cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_;
+			return cb_getSomeObjectProperty_GetSomeObjectProperty_Ljava_lang_Object_ ??= new _JniMarshal_PP_L (n_GetSomeObjectProperty);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetSomeObjectProperty (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.SomeObjectProperty);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.SomeObjectProperty);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -108,16 +131,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetSomeObjectProperty_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V == null)
-				cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeObjectProperty_Ljava_lang_Object_));
-			return cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V;
+			return cb_setSomeObjectProperty_SetSomeObjectProperty_Ljava_lang_Object__V ??= new _JniMarshal_PPL_V (n_SetSomeObjectProperty_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeObjectProperty_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
-			__this.SomeObjectProperty = newvalue;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var newvalue = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_newvalue, JniHandleOwnership.DoNotTransfer);
+				__this.SomeObjectProperty = newvalue;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -135,15 +165,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetGetSomeStringHandler ()
 		{
-			if (cb_getSomeString_GetSomeString_Ljava_lang_String_ == null)
-				cb_getSomeString_GetSomeString_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetSomeString));
-			return cb_getSomeString_GetSomeString_Ljava_lang_String_;
+			return cb_getSomeString_GetSomeString_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_GetSomeString);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetSomeString (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewString (__this.SomeString);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewString (__this.SomeString);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -151,16 +189,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetSomeString_Ljava_lang_String_Handler ()
 		{
-			if (cb_setSomeString_SetSomeString_Ljava_lang_String__V == null)
-				cb_setSomeString_SetSomeString_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetSomeString_Ljava_lang_String_));
-			return cb_setSomeString_SetSomeString_Ljava_lang_String__V;
+			return cb_setSomeString_SetSomeString_Ljava_lang_String__V ??= new _JniMarshal_PPL_V (n_SetSomeString_Ljava_lang_String_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetSomeString_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_newvalue)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
-			__this.SomeString = newvalue;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.SomeObject> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var newvalue = JNIEnv.GetString (native_newvalue, JniHandleOwnership.DoNotTransfer);
+				__this.SomeString = newvalue;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -98,7 +98,7 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -51,16 +51,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetSetA_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setA_SetA_Ljava_lang_Object__V == null)
-				cb_setA_SetA_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetA_Ljava_lang_Object_));
-			return cb_setA_SetA_Ljava_lang_Object__V;
+			return cb_setA_SetA_Ljava_lang_Object__V ??= new _JniMarshal_PPL_V (n_SetA_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
-			__this.SetA (adapter);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
+				__this.SetA (adapter);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -84,16 +91,23 @@ namespace Xamarin.Test {
 #pragma warning disable 0169
 		static Delegate GetListTest_Ljava_util_List_Handler ()
 		{
-			if (cb_listTest_ListTest_Ljava_util_List__V == null)
-				cb_listTest_ListTest_Ljava_util_List__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_ListTest_Ljava_util_List_));
-			return cb_listTest_ListTest_Ljava_util_List__V;
+			return cb_listTest_ListTest_Ljava_util_List__V ??= new _JniMarshal_PPL_V (n_ListTest_Ljava_util_List_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
-			__this.ListTest (p0);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
+				__this.ListTest (p0);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -58,13 +58,15 @@ namespace Xamarin.Test {
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 				__this.SetA (adapter);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -98,13 +100,15 @@ namespace Xamarin.Test {
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 				__this.ListTest (p0);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/Xamarin.Test.A.cs
@@ -57,18 +57,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetA_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_adapter)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var adapter = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_adapter, JniHandleOwnership.DoNotTransfer);
 				__this.SetA (adapter);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -99,18 +98,17 @@ namespace Xamarin.Test {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_ListTest_Ljava_util_List_ (IntPtr jnienv, IntPtr native__this, IntPtr native_p0)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Xamarin.Test.A> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var p0 = global::Android.Runtime.JavaList<global::Java.Lang.Integer>.FromJniHandle (native_p0, JniHandleOwnership.DoNotTransfer);
 				__this.ListTest (p0);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -79,12 +79,14 @@ namespace Java.IO {
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Write (oneByte);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -78,7 +78,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -72,15 +72,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetWrite_IHandler ()
 		{
-			if (cb_write_Write_I_V == null)
-				cb_write_Write_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
-			return cb_write_Write_I_V;
+			return cb_write_Write_I_V ??= new _JniMarshal_PPI_V (n_Write_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Write (oneByte);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Write (oneByte);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.FilterOutputStream.cs
@@ -78,17 +78,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.FilterOutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Write (oneByte);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -50,15 +50,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetPrintStackTraceHandler ()
 		{
-			if (cb_printStackTrace_PrintStackTrace_V == null)
-				cb_printStackTrace_PrintStackTrace_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_PrintStackTrace));
-			return cb_printStackTrace_PrintStackTrace_V;
+			return cb_printStackTrace_PrintStackTrace_V ??= new _JniMarshal_PP_V (n_PrintStackTrace);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.PrintStackTrace ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.PrintStackTrace ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -57,12 +57,14 @@ namespace Java.IO {
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.PrintStackTrace ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -56,7 +56,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.IOException.cs
@@ -56,17 +56,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_PrintStackTrace (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.IOException> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.PrintStackTrace ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -73,7 +73,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -110,7 +110,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -145,7 +145,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -182,7 +182,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -219,7 +219,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -248,7 +248,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -297,7 +297,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -348,7 +348,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -383,7 +383,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -74,12 +74,14 @@ namespace Java.IO {
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Available ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -110,12 +112,14 @@ namespace Java.IO {
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -144,12 +148,14 @@ namespace Java.IO {
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Mark (readlimit);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -180,12 +186,14 @@ namespace Java.IO {
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.MarkSupported ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -216,12 +224,14 @@ namespace Java.IO {
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Read ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -244,8 +254,10 @@ namespace Java.IO {
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				int __ret = __this.Read (buffer);
@@ -253,7 +265,7 @@ namespace Java.IO {
 					JNIEnv.CopyArray (buffer, native_buffer);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -292,8 +304,10 @@ namespace Java.IO {
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				int __ret = __this.Read (buffer, byteOffset, byteCount);
@@ -301,7 +315,7 @@ namespace Java.IO {
 					JNIEnv.CopyArray (buffer, native_buffer);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -342,12 +356,14 @@ namespace Java.IO {
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Reset ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -376,12 +392,14 @@ namespace Java.IO {
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Skip (byteCount);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -67,15 +67,23 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetAvailableHandler ()
 		{
-			if (cb_available_Available_I == null)
-				cb_available_Available_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Available));
-			return cb_available_Available_I;
+			return cb_available_Available_I ??= new _JniMarshal_PP_I (n_Available);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.Available ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.Available ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -95,15 +103,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close_Close_V == null)
-				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close_Close_V;
+			return cb_close_Close_V ??= new _JniMarshal_PP_V (n_Close);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Close ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Close ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -122,15 +137,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetMark_IHandler ()
 		{
-			if (cb_mark_Mark_I_V == null)
-				cb_mark_Mark_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Mark_I));
-			return cb_mark_Mark_I_V;
+			return cb_mark_Mark_I_V ??= new _JniMarshal_PPI_V (n_Mark_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Mark (readlimit);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Mark (readlimit);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -151,15 +173,23 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetMarkSupportedHandler ()
 		{
-			if (cb_markSupported_MarkSupported_Z == null)
-				cb_markSupported_MarkSupported_Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_Z (n_MarkSupported));
-			return cb_markSupported_MarkSupported_Z;
+			return cb_markSupported_MarkSupported_Z ??= new _JniMarshal_PP_Z (n_MarkSupported);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.MarkSupported ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.MarkSupported ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -179,15 +209,23 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetReadHandler ()
 		{
-			if (cb_read_Read_I == null)
-				cb_read_Read_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_I (n_Read));
-			return cb_read_Read_I;
+			return cb_read_Read_I ??= new _JniMarshal_PP_I (n_Read);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.Read ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.Read ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -199,19 +237,27 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetRead_arrayBHandler ()
 		{
-			if (cb_read_Read_arrayB_I == null)
-				cb_read_Read_arrayB_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_Read_arrayB));
-			return cb_read_Read_arrayB_I;
+			return cb_read_Read_arrayB_I ??= new _JniMarshal_PPL_I (n_Read_arrayB);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			int __ret = __this.Read (buffer);
-			if (buffer != null)
-				JNIEnv.CopyArray (buffer, native_buffer);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				int __ret = __this.Read (buffer);
+				if (buffer != null)
+					JNIEnv.CopyArray (buffer, native_buffer);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -239,19 +285,27 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetRead_arrayBIIHandler ()
 		{
-			if (cb_read_Read_arrayBII_I == null)
-				cb_read_Read_arrayBII_I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_I (n_Read_arrayBII));
-			return cb_read_Read_arrayBII_I;
+			return cb_read_Read_arrayBII_I ??= new _JniMarshal_PPLII_I (n_Read_arrayBII);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			int __ret = __this.Read (buffer, byteOffset, byteCount);
-			if (buffer != null)
-				JNIEnv.CopyArray (buffer, native_buffer);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				int __ret = __this.Read (buffer, byteOffset, byteCount);
+				if (buffer != null)
+					JNIEnv.CopyArray (buffer, native_buffer);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -281,15 +335,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetResetHandler ()
 		{
-			if (cb_reset_Reset_V == null)
-				cb_reset_Reset_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Reset));
-			return cb_reset_Reset_V;
+			return cb_reset_Reset_V ??= new _JniMarshal_PP_V (n_Reset);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Reset ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Reset ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -308,15 +369,23 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetSkip_JHandler ()
 		{
-			if (cb_skip_Skip_J_J == null)
-				cb_skip_Skip_J_J = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPJ_J (n_Skip_J));
-			return cb_skip_Skip_J_J;
+			return cb_skip_Skip_J_J ??= new _JniMarshal_PPJ_J (n_Skip_J);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return __this.Skip (byteCount);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return __this.Skip (byteCount);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.InputStream.cs
@@ -73,18 +73,17 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Available (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Available ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -111,17 +110,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -147,17 +145,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Mark_I (IntPtr jnienv, IntPtr native__this, int readlimit)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Mark (readlimit);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -185,18 +182,17 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_MarkSupported (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.MarkSupported ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -223,18 +219,17 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Read ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -253,11 +248,10 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				int __ret = __this.Read (buffer);
@@ -268,7 +262,7 @@ namespace Java.IO {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -303,11 +297,10 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_Read_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int byteOffset, int byteCount)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				int __ret = __this.Read (buffer, byteOffset, byteCount);
@@ -318,7 +311,7 @@ namespace Java.IO {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -355,17 +348,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Reset (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Reset ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -391,18 +383,17 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static long n_Skip_J (IntPtr jnienv, IntPtr native__this, long byteCount)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.InputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return __this.Skip (byteCount);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -73,17 +73,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -109,17 +108,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Flush ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -145,11 +143,10 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				__this.Write (buffer);
@@ -158,7 +155,7 @@ namespace Java.IO {
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -192,11 +189,10 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				__this.Write (buffer, offset, count);
@@ -205,7 +201,7 @@ namespace Java.IO {
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -241,17 +237,16 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Write (oneByte);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -74,12 +74,14 @@ namespace Java.IO {
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Close ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -108,12 +110,14 @@ namespace Java.IO {
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Flush ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -142,15 +146,17 @@ namespace Java.IO {
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				__this.Write (buffer);
 				if (buffer != null)
 					JNIEnv.CopyArray (buffer, native_buffer);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -187,15 +193,17 @@ namespace Java.IO {
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				__this.Write (buffer, offset, count);
 				if (buffer != null)
 					JNIEnv.CopyArray (buffer, native_buffer);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -234,12 +242,14 @@ namespace Java.IO {
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Write (oneByte);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -67,15 +67,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetCloseHandler ()
 		{
-			if (cb_close_Close_V == null)
-				cb_close_Close_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Close));
-			return cb_close_Close_V;
+			return cb_close_Close_V ??= new _JniMarshal_PP_V (n_Close);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Close ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Close ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -94,15 +101,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetFlushHandler ()
 		{
-			if (cb_flush_Flush_V == null)
-				cb_flush_Flush_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Flush));
-			return cb_flush_Flush_V;
+			return cb_flush_Flush_V ??= new _JniMarshal_PP_V (n_Flush);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Flush ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Flush ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -121,18 +135,25 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetWrite_arrayBHandler ()
 		{
-			if (cb_write_Write_arrayB_V == null)
-				cb_write_Write_arrayB_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Write_arrayB));
-			return cb_write_Write_arrayB_V;
+			return cb_write_Write_arrayB_V ??= new _JniMarshal_PPL_V (n_Write_arrayB);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			__this.Write (buffer);
-			if (buffer != null)
-				JNIEnv.CopyArray (buffer, native_buffer);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				__this.Write (buffer);
+				if (buffer != null)
+					JNIEnv.CopyArray (buffer, native_buffer);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -159,18 +180,25 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetWrite_arrayBIIHandler ()
 		{
-			if (cb_write_Write_arrayBII_V == null)
-				cb_write_Write_arrayBII_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPLII_V (n_Write_arrayBII));
-			return cb_write_Write_arrayBII_V;
+			return cb_write_Write_arrayBII_V ??= new _JniMarshal_PPLII_V (n_Write_arrayBII);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			__this.Write (buffer, offset, count);
-			if (buffer != null)
-				JNIEnv.CopyArray (buffer, native_buffer);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var buffer = (byte[]) JNIEnv.GetArray (native_buffer, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				__this.Write (buffer, offset, count);
+				if (buffer != null)
+					JNIEnv.CopyArray (buffer, native_buffer);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -199,15 +227,22 @@ namespace Java.IO {
 #pragma warning disable 0169
 		static Delegate GetWrite_IHandler ()
 		{
-			if (cb_write_Write_I_V == null)
-				cb_write_Write_I_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPI_V (n_Write_I));
-			return cb_write_Write_I_V;
+			return cb_write_Write_I_V ??= new _JniMarshal_PPI_V (n_Write_I);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Write (oneByte);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.IO.OutputStream> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Write (oneByte);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.IO.OutputStream.cs
@@ -73,7 +73,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Close (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -108,7 +108,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Flush (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -143,7 +143,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -189,7 +189,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_arrayBII (IntPtr jnienv, IntPtr native__this, IntPtr native_buffer, int offset, int count)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -237,7 +237,7 @@ namespace Java.IO {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Write_I (IntPtr jnienv, IntPtr native__this, int oneByte)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -28,15 +28,23 @@ namespace Java.Lang {
 #pragma warning disable 0169
 		static Delegate GetGetMessageHandler ()
 		{
-			if (cb_getMessage_GetMessage_Ljava_lang_String_ == null)
-				cb_getMessage_GetMessage_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetMessage));
-			return cb_getMessage_GetMessage_Ljava_lang_String_;
+			return cb_getMessage_GetMessage_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_GetMessage);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewString (__this.Message);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewString (__this.Message);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -35,12 +35,14 @@ namespace Java.Lang {
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.Message);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -34,7 +34,7 @@ namespace Java.Lang {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/Java.Lang.Throwable.cs
@@ -34,18 +34,17 @@ namespace Java.Lang {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetMessage (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.Throwable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.Message);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -71,7 +71,7 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -71,17 +71,16 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<ClassWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -72,12 +72,14 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<ClassWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/ClassWithoutNamespace.cs
@@ -65,15 +65,22 @@ public abstract partial class ClassWithoutNamespace : global::Java.Lang.Object, 
 #pragma warning disable 0169
 	static Delegate GetFooHandler ()
 	{
-		if (cb_Foo_Foo_V == null)
-			cb_Foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-		return cb_Foo_Foo_V;
+		return cb_Foo_Foo_V ??= new _JniMarshal_PP_V (n_Foo);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<ClassWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.Foo ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<ClassWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Foo ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -46,15 +46,22 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 #pragma warning disable 0169
 	static Delegate GetFooHandler ()
 	{
-		if (cb_Foo_Foo_V == null)
-			cb_Foo_Foo_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Foo));
-		return cb_Foo_Foo_V;
+		return cb_Foo_Foo_V ??= new _JniMarshal_PP_V (n_Foo);
 	}
 
+	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		var __this = global::Java.Lang.Object.GetObject<IInterfaceWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-		__this.Foo ();
+		var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+		try {
+			var __this = global::Java.Lang.Object.GetObject<IInterfaceWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+			__this.Foo ();
+		} catch (global::System.Exception __e) {
+			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+		} finally {
+			__envp.Dispose ();
+		}
 	}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -52,17 +52,16 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		var __envp = new global::Java.Interop.JniTransition (jnienv);
-		var __r = global::Java.Interop.JniEnvironment.Runtime;
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			return;
 
 		try {
-			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<IInterfaceWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		} catch (global::System.Exception __e) {
 			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
-			__envp.Dispose ();
+			global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 		}
 	}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -53,12 +53,14 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
 		var __envp = new global::Java.Interop.JniTransition (jnienv);
+		var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 		try {
+			__r.OnEnterMarshalMethod ();
 			var __this = global::Java.Lang.Object.GetObject<IInterfaceWithoutNamespace> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 			__this.Foo ();
 		} catch (global::System.Exception __e) {
-			global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			__r.OnUserUnhandledException (ref __envp, __e);
 		} finally {
 			__envp.Dispose ();
 		}

--- a/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/IInterfaceWithoutNamespace.cs
@@ -52,7 +52,7 @@ internal partial class IInterfaceWithoutNamespaceInvoker : global::Java.Lang.Obj
 	[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 	static void n_Foo (IntPtr jnienv, IntPtr native__this)
 	{
-		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+		if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 			return;
 
 		try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
@@ -59,11 +59,10 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.Add (e);
@@ -72,7 +71,7 @@ namespace Java.Util {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -102,17 +101,16 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Clear ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
@@ -60,14 +60,16 @@ namespace Java.Util {
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.Add (e);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -101,12 +103,14 @@ namespace Java.Util {
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Clear ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
@@ -53,17 +53,25 @@ namespace Java.Util {
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
-			if (cb_add_Add_Ljava_lang_Object__Z == null)
-				cb_add_Add_Ljava_lang_Object__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
-			return cb_add_Add_Ljava_lang_Object__Z;
+			return cb_add_Add_Ljava_lang_Object__Z ??= new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.Add (e);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
+				bool __ret = __this.Add (e);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -86,15 +94,22 @@ namespace Java.Util {
 #pragma warning disable 0169
 		static Delegate GetClearHandler ()
 		{
-			if (cb_clear_Clear_V == null)
-				cb_clear_Clear_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
-			return cb_clear_Clear_V;
+			return cb_clear_Clear_V ??= new _JniMarshal_PP_V (n_Clear);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Clear ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.ICollection> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Clear ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.ICollection.cs
@@ -59,7 +59,7 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -101,7 +101,7 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
@@ -60,14 +60,16 @@ namespace Java.Util {
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.Add (e);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -101,12 +103,14 @@ namespace Java.Util {
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Clear ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
@@ -59,11 +59,10 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.Add (e);
@@ -72,7 +71,7 @@ namespace Java.Util {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -102,17 +101,16 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Clear ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
@@ -53,17 +53,25 @@ namespace Java.Util {
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
-			if (cb_add_Add_Ljava_lang_Object__Z == null)
-				cb_add_Add_Ljava_lang_Object__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
-			return cb_add_Add_Ljava_lang_Object__Z;
+			return cb_add_Add_Ljava_lang_Object__Z ??= new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.Add (e);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
+				bool __ret = __this.Add (e);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -86,15 +94,22 @@ namespace Java.Util {
 #pragma warning disable 0169
 		static Delegate GetClearHandler ()
 		{
-			if (cb_clear_Clear_V == null)
-				cb_clear_Clear_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
-			return cb_clear_Clear_V;
+			return cb_clear_Clear_V ??= new _JniMarshal_PP_V (n_Clear);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Clear ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IDeque> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Clear ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IDeque.cs
@@ -59,7 +59,7 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -101,7 +101,7 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
@@ -51,17 +51,25 @@ namespace Java.Util {
 #pragma warning disable 0169
 		static Delegate GetAdd_Ljava_lang_Object_Handler ()
 		{
-			if (cb_add_Add_Ljava_lang_Object__Z == null)
-				cb_add_Add_Ljava_lang_Object__Z = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_));
-			return cb_add_Add_Ljava_lang_Object__Z;
+			return cb_add_Add_Ljava_lang_Object__Z ??= new _JniMarshal_PPL_Z (n_Add_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
-			bool __ret = __this.Add (e);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
+				bool __ret = __this.Add (e);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -84,15 +92,22 @@ namespace Java.Util {
 #pragma warning disable 0169
 		static Delegate GetClearHandler ()
 		{
-			if (cb_clear_Clear_V == null)
-				cb_clear_Clear_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_V (n_Clear));
-			return cb_clear_Clear_V;
+			return cb_clear_Clear_V ??= new _JniMarshal_PP_V (n_Clear);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			__this.Clear ();
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				__this.Clear ();
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
@@ -57,7 +57,7 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -99,7 +99,7 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
@@ -57,11 +57,10 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.Add (e);
@@ -70,7 +69,7 @@ namespace Java.Util {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -100,17 +99,16 @@ namespace Java.Util {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Clear ();
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Java.Util.IQueue.cs
@@ -58,14 +58,16 @@ namespace Java.Util {
 		static bool n_Add_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_e)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var e = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_e, JniHandleOwnership.DoNotTransfer);
 				bool __ret = __this.Add (e);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -99,12 +101,14 @@ namespace Java.Util {
 		static void n_Clear (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Util.IQueue> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				__this.Clear ();
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -74,15 +74,17 @@ namespace Test.ME {
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				__this.SetObject (value);
 				if (value != null)
 					JNIEnv.CopyArray (value, native_value);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -73,7 +73,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -73,11 +73,10 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
 				__this.SetObject (value);
@@ -86,7 +85,7 @@ namespace Test.ME {
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericImplementation.cs
@@ -67,18 +67,25 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetSetObject_arrayBHandler ()
 		{
-			if (cb_SetObject_SetObject_arrayB_V == null)
-				cb_SetObject_SetObject_arrayB_V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayB));
-			return cb_SetObject_SetObject_arrayB_V;
+			return cb_SetObject_SetObject_arrayB_V ??= new _JniMarshal_PPL_V (n_SetObject_arrayB);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_arrayB (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
-			__this.SetObject (value);
-			if (value != null)
-				JNIEnv.CopyArray (value, native_value);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = (byte[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (byte));
+				__this.SetObject (value);
+				if (value != null)
+					JNIEnv.CopyArray (value, native_value);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -74,12 +74,14 @@ namespace Test.ME {
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.Object);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -98,13 +100,15 @@ namespace Test.ME {
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
 				__this.Object = @object;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -73,18 +73,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.Object);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -99,18 +98,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
 				__this.Object = @object;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -73,7 +73,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -98,7 +98,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericObjectPropertyImplementation.cs
@@ -67,15 +67,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetGetObjectHandler ()
 		{
-			if (cb_getObject_GetObject_Ljava_lang_Object_ == null)
-				cb_getObject_GetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
-			return cb_getObject_GetObject_Ljava_lang_Object_;
+			return cb_getObject_GetObject_Ljava_lang_Object_ ??= new _JniMarshal_PP_L (n_GetObject);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.Object);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.Object);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -83,16 +91,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setObject_SetObject_Ljava_lang_Object__V == null)
-				cb_setObject_SetObject_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
-			return cb_setObject_SetObject_Ljava_lang_Object__V;
+			return cb_setObject_SetObject_Ljava_lang_Object__V ??= new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
-			__this.Object = @object;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericObjectPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
+				__this.Object = @object;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -74,15 +74,17 @@ namespace Test.ME {
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
 				__this.SetObject (value);
 				if (value != null)
 					JNIEnv.CopyArray (value, native_value);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -67,18 +67,25 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetSetObject_arrayLjava_lang_String_Handler ()
 		{
-			if (cb_SetObject_SetObject_arrayLjava_lang_String__V == null)
-				cb_SetObject_SetObject_arrayLjava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_arrayLjava_lang_String_));
-			return cb_SetObject_SetObject_arrayLjava_lang_String__V;
+			return cb_SetObject_SetObject_arrayLjava_lang_String__V ??= new _JniMarshal_PPL_V (n_SetObject_arrayLjava_lang_String_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
-			__this.SetObject (value);
-			if (value != null)
-				JNIEnv.CopyArray (value, native_value);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
+				__this.SetObject (value);
+				if (value != null)
+					JNIEnv.CopyArray (value, native_value);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -73,7 +73,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringImplementation.cs
@@ -73,11 +73,10 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_arrayLjava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = (string[]) JNIEnv.GetArray (native_value, JniHandleOwnership.DoNotTransfer, typeof (string));
 				__this.SetObject (value);
@@ -86,7 +85,7 @@ namespace Test.ME {
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -73,18 +73,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.Object);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -99,18 +98,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var @object = JNIEnv.GetString (native__object, JniHandleOwnership.DoNotTransfer);
 				__this.Object = @object;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -67,15 +67,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetGetObjectHandler ()
 		{
-			if (cb_getObject_GetObject_Ljava_lang_String_ == null)
-				cb_getObject_GetObject_Ljava_lang_String_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
-			return cb_getObject_GetObject_Ljava_lang_String_;
+			return cb_getObject_GetObject_Ljava_lang_String_ ??= new _JniMarshal_PP_L (n_GetObject);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.NewString (__this.Object);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.NewString (__this.Object);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -83,16 +91,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_String_Handler ()
 		{
-			if (cb_SetObject_SetObject_Ljava_lang_String__V == null)
-				cb_SetObject_SetObject_Ljava_lang_String__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_String_));
-			return cb_SetObject_SetObject_Ljava_lang_String__V;
+			return cb_SetObject_SetObject_Ljava_lang_String__V ??= new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_String_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var @object = JNIEnv.GetString (native__object, JniHandleOwnership.DoNotTransfer);
-			__this.Object = @object;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var @object = JNIEnv.GetString (native__object, JniHandleOwnership.DoNotTransfer);
+				__this.Object = @object;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -74,12 +74,14 @@ namespace Test.ME {
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.NewString (__this.Object);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -98,13 +100,15 @@ namespace Test.ME {
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.GenericStringPropertyImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var @object = JNIEnv.GetString (native__object, JniHandleOwnership.DoNotTransfer);
 				__this.Object = @object;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.GenericStringPropertyImplementation.cs
@@ -73,7 +73,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -98,7 +98,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_String_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -55,18 +55,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 				__this.SetObject (value);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -56,13 +56,15 @@ namespace Test.ME {
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
 				__this.SetObject (value);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -55,7 +55,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericInterface.cs
@@ -49,16 +49,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
-			if (cb_SetObject_SetObject_Ljava_lang_Object__V == null)
-				cb_SetObject_SetObject_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
-			return cb_SetObject_SetObject_Ljava_lang_Object__V;
+			return cb_SetObject_SetObject_Ljava_lang_Object__V ??= new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
-			__this.SetObject (value);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_value, JniHandleOwnership.DoNotTransfer);
+				__this.SetObject (value);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -55,15 +55,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetGetObjectHandler ()
 		{
-			if (cb_getObject_GetObject_Ljava_lang_Object_ == null)
-				cb_getObject_GetObject_Ljava_lang_Object_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PP_L (n_GetObject));
-			return cb_getObject_GetObject_Ljava_lang_Object_;
+			return cb_getObject_GetObject_Ljava_lang_Object_ ??= new _JniMarshal_PP_L (n_GetObject);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			return JNIEnv.ToLocalJniHandle (__this.Object);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				return JNIEnv.ToLocalJniHandle (__this.Object);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -71,16 +79,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetSetObject_Ljava_lang_Object_Handler ()
 		{
-			if (cb_setObject_SetObject_Ljava_lang_Object__V == null)
-				cb_setObject_SetObject_Ljava_lang_Object__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_));
-			return cb_setObject_SetObject_Ljava_lang_Object__V;
+			return cb_setObject_SetObject_Ljava_lang_Object__V ??= new _JniMarshal_PPL_V (n_SetObject_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
-			__this.Object = @object;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
+				__this.Object = @object;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -61,7 +61,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -86,7 +86,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -62,12 +62,14 @@ namespace Test.ME {
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.Object);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -86,13 +88,15 @@ namespace Test.ME {
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
 				__this.Object = @object;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.IGenericPropertyInterface.cs
@@ -61,18 +61,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_GetObject (IntPtr jnienv, IntPtr native__this)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				return JNIEnv.ToLocalJniHandle (__this.Object);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -87,18 +86,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_SetObject_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native__object)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.IGenericPropertyInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var @object = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native__object, JniHandleOwnership.DoNotTransfer);
 				__this.Object = @object;
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -116,7 +116,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -156,7 +156,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -195,7 +195,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -117,14 +117,16 @@ namespace Test.ME {
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.GetSpanFlags (tag);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -156,13 +158,15 @@ namespace Test.ME {
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				__this.Append (value);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -194,14 +198,16 @@ namespace Test.ME {
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -110,17 +110,25 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
-				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
-			int __ret = __this.GetSpanFlags (tag);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+				int __ret = __this.GetSpanFlags (tag);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -141,16 +149,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_append_Append_Ljava_lang_CharSequence__V == null)
-				cb_append_Append_Ljava_lang_CharSequence__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
-			return cb_append_Append_Ljava_lang_CharSequence__V;
+			return cb_append_Append_Ljava_lang_CharSequence__V ??= new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
-			__this.Append (value);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+				__this.Append (value);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -172,17 +187,25 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ == null)
-				cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
-			return cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_;
+			return cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ ??= new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
-			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+				IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.ITestInterface.cs
@@ -116,11 +116,10 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.GetSpanFlags (tag);
@@ -129,7 +128,7 @@ namespace Test.ME {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -157,18 +156,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				__this.Append (value);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -197,11 +195,10 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.ITestInterface> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
@@ -210,7 +207,7 @@ namespace Test.ME {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -94,11 +94,10 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.GetSpanFlags (tag);
@@ -107,7 +106,7 @@ namespace Test.ME {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -126,18 +125,17 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				__this.Append (value);
 			} catch (global::System.Exception __e) {
 				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169
@@ -163,11 +161,10 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
@@ -176,7 +173,7 @@ namespace Test.ME {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -94,7 +94,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {
@@ -125,7 +125,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return;
 
 			try {
@@ -161,7 +161,7 @@ namespace Test.ME {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -88,17 +88,25 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetGetSpanFlags_Ljava_lang_Object_Handler ()
 		{
-			if (cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I == null)
-				cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_));
-			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I;
+			return cb_getSpanFlags_GetSpanFlags_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_GetSpanFlags_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
-			int __ret = __this.GetSpanFlags (tag);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
+				int __ret = __this.GetSpanFlags (tag);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -110,16 +118,23 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetAppend_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_append_Append_Ljava_lang_CharSequence__V == null)
-				cb_append_Append_Ljava_lang_CharSequence__V = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_));
-			return cb_append_Append_Ljava_lang_CharSequence__V;
+			return cb_append_Append_Ljava_lang_CharSequence__V ??= new _JniMarshal_PPL_V (n_Append_Ljava_lang_CharSequence_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
-			__this.Append (value);
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+				__this.Append (value);
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 
@@ -138,17 +153,25 @@ namespace Test.ME {
 #pragma warning disable 0169
 		static Delegate GetIdentity_Ljava_lang_CharSequence_Handler ()
 		{
-			if (cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ == null)
-				cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_));
-			return cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_;
+			return cb_identity_Identity_Ljava_lang_CharSequence__Ljava_lang_CharSequence_ ??= new _JniMarshal_PPL_L (n_Identity_Ljava_lang_CharSequence_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
-			IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
+				IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/Test.ME.TestInterfaceImplementation.cs
@@ -95,14 +95,16 @@ namespace Test.ME {
 		static int n_GetSpanFlags_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_tag)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var tag = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_tag, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.GetSpanFlags (tag);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();
@@ -125,13 +127,15 @@ namespace Test.ME {
 		static void n_Append_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				__this.Append (value);
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 			} finally {
 				__envp.Dispose ();
 			}
@@ -160,14 +164,16 @@ namespace Test.ME {
 		static IntPtr n_Identity_Ljava_lang_CharSequence_ (IntPtr jnienv, IntPtr native__this, IntPtr native_value)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Test.ME.TestInterfaceImplementation> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var value = global::Java.Lang.Object.GetObject<global::Java.Lang.ICharSequence> (native_value, JniHandleOwnership.DoNotTransfer);
 				IntPtr __ret = CharSequence.ToLocalJniHandle (__this.IdentityFormatted (value));
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -55,7 +55,7 @@ namespace Java.Lang {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)
 		{
-			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))
 				return default;
 
 			try {

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -55,11 +55,10 @@ namespace Java.Lang {
 		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)
 		{
-			var __envp = new global::Java.Interop.JniTransition (jnienv);
-			var __r = global::Java.Interop.JniEnvironment.Runtime;
+			if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) 
+				return default;
 
 			try {
-				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.CompareTo (another);
@@ -68,7 +67,7 @@ namespace Java.Lang {
 				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
-				__envp.Dispose ();
+				global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);
 			}
 		}
 #pragma warning restore 0169

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -56,14 +56,16 @@ namespace Java.Lang {
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)
 		{
 			var __envp = new global::Java.Interop.JniTransition (jnienv);
+			var __r = global::Java.Interop.JniEnvironment.Runtime;
 
 			try {
+				__r.OnEnterMarshalMethod ();
 				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
 				var another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
 				int __ret = __this.CompareTo (another);
 				return __ret;
 			} catch (global::System.Exception __e) {
-				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				__r.OnUserUnhandledException (ref __envp, __e);
 				return default;
 			} finally {
 				__envp.Dispose ();

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/Java.Lang.IComparable.cs
@@ -49,17 +49,25 @@ namespace Java.Lang {
 #pragma warning disable 0169
 		static Delegate GetCompareTo_Ljava_lang_Object_Handler ()
 		{
-			if (cb_compareTo_CompareTo_Ljava_lang_Object__I == null)
-				cb_compareTo_CompareTo_Ljava_lang_Object__I = JNINativeWrapper.CreateDelegate (new _JniMarshal_PPL_I (n_CompareTo_Ljava_lang_Object_));
-			return cb_compareTo_CompareTo_Ljava_lang_Object__I;
+			return cb_compareTo_CompareTo_Ljava_lang_Object__I ??= new _JniMarshal_PPL_I (n_CompareTo_Ljava_lang_Object_);
 		}
 
+		[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]
 		static int n_CompareTo_Ljava_lang_Object_ (IntPtr jnienv, IntPtr native__this, IntPtr native_another)
 		{
-			var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
-			var another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
-			int __ret = __this.CompareTo (another);
-			return __ret;
+			var __envp = new global::Java.Interop.JniTransition (jnienv);
+
+			try {
+				var __this = global::Java.Lang.Object.GetObject<global::Java.Lang.IComparable> (jnienv, native__this, JniHandleOwnership.DoNotTransfer);
+				var another = global::Java.Lang.Object.GetObject<global::Java.Lang.Object> (native_another, JniHandleOwnership.DoNotTransfer);
+				int __ret = __this.CompareTo (another);
+				return __ret;
+			} catch (global::System.Exception __e) {
+				global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);
+				return default;
+			} finally {
+				__envp.Dispose ();
+			}
 		}
 #pragma warning restore 0169
 

--- a/tools/generator/SourceWriters/Attributes/DebuggerDisableUserUnhandledExceptionsAttributeAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/DebuggerDisableUserUnhandledExceptionsAttributeAttr.cs
@@ -11,7 +11,7 @@ namespace generator.SourceWriters
 	{
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			writer.WriteLine ("[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptionsAttribute]");
+			writer.WriteLine ("[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptions]");
 		}
 	}
 }

--- a/tools/generator/SourceWriters/Attributes/DebuggerDisableUserUnhandledExceptionsAttributeAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/DebuggerDisableUserUnhandledExceptionsAttributeAttr.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	public class DebuggerDisableUserUnhandledExceptionsAttributeAttr : AttributeWriter
+	{
+		public override void WriteAttribute (CodeWriter writer)
+		{
+			writer.WriteLine ("[global::System.Diagnostics.DebuggerDisableUserUnhandledExceptionsAttribute]");
+		}
+	}
+}

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -91,7 +91,7 @@ namespace generator.SourceWriters
 
 			writer.WriteLine ("} catch (global::System.Exception __e) {");
 			writer.Indent ();
-			writer.WriteLine ("JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);");
+			writer.WriteLine ("global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);");
 
 			if (!method.IsVoid)
 				writer.WriteLine ("return default;");

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -58,13 +58,15 @@ namespace generator.SourceWriters
 
 		protected override void WriteBody (CodeWriter writer)
 		{
-			writer.WriteLine ("var __envp = new global::Java.Interop.JniTransition (jnienv);");
-			writer.WriteLine ("var __r = global::Java.Interop.JniEnvironment.Runtime;");
+			writer.WriteLine ("if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) ");
+			writer.Indent ();
+			writer.WriteLine (method.IsVoid ? "return;" : "return default;");
+			writer.Unindent ();
+
 			writer.WriteLine ();
 			writer.WriteLine ("try {");
 
 			writer.Indent ();
-			writer.WriteLine ("__r.OnEnterMarshalMethod ();");
 			writer.WriteLine ($"var __this = global::Java.Lang.Object.GetObject<{opt.GetOutputName (type.FullName)}> (jnienv, native__this, JniHandleOwnership.DoNotTransfer){opt.NullForgivingOperator};");
 
 			foreach (var s in method.Parameters.GetCallbackPrep (opt))
@@ -101,7 +103,7 @@ namespace generator.SourceWriters
 			writer.Unindent ();
 			writer.WriteLine ("} finally {");
 			writer.Indent ();
-			writer.WriteLine ("__envp.Dispose ();");
+			writer.WriteLine ("global::Java.Interop.JniEnvironment.EndMarshalMethod (ref __envp);");
 			writer.Unindent ();
 			writer.WriteLine ("}");
 

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -58,7 +58,7 @@ namespace generator.SourceWriters
 
 		protected override void WriteBody (CodeWriter writer)
 		{
-			writer.WriteLine ("if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r)) ");
+			writer.WriteLine ("if (!global::Java.Interop.JniEnvironment.BeginMarshalMethod (jnienv, out var __envp, out var __r))");
 			writer.Indent ();
 			writer.WriteLine (method.IsVoid ? "return;" : "return default;");
 			writer.Unindent ();

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -91,8 +91,7 @@ namespace generator.SourceWriters
 
 			writer.WriteLine ("} catch (global::System.Exception __e) {");
 			writer.Indent ();
-			writer.WriteLine ("__envp.SetPendingException (__e);");
-			writer.WriteLine ("global::System.Diagnostics.Debugger.BreakForUserUnhandledException (__e);");
+			writer.WriteLine ("JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);");
 
 			if (!method.IsVoid)
 				writer.WriteLine ("return default;");

--- a/tools/generator/SourceWriters/MethodCallback.cs
+++ b/tools/generator/SourceWriters/MethodCallback.cs
@@ -59,10 +59,12 @@ namespace generator.SourceWriters
 		protected override void WriteBody (CodeWriter writer)
 		{
 			writer.WriteLine ("var __envp = new global::Java.Interop.JniTransition (jnienv);");
+			writer.WriteLine ("var __r = global::Java.Interop.JniEnvironment.Runtime;");
 			writer.WriteLine ();
 			writer.WriteLine ("try {");
 
 			writer.Indent ();
+			writer.WriteLine ("__r.OnEnterMarshalMethod ();");
 			writer.WriteLine ($"var __this = global::Java.Lang.Object.GetObject<{opt.GetOutputName (type.FullName)}> (jnienv, native__this, JniHandleOwnership.DoNotTransfer){opt.NullForgivingOperator};");
 
 			foreach (var s in method.Parameters.GetCallbackPrep (opt))
@@ -91,7 +93,7 @@ namespace generator.SourceWriters
 
 			writer.WriteLine ("} catch (global::System.Exception __e) {");
 			writer.Indent ();
-			writer.WriteLine ("global::Java.Interop.JniEnvironment.Runtime.OnUserUnhandledException (ref __envp, __e);");
+			writer.WriteLine ("__r.OnUserUnhandledException (ref __envp, __e);");
 
 			if (!method.IsVoid)
 				writer.WriteLine ("return default;");


### PR DESCRIPTION
Fixes: #1258

Change generated marshal methods to use an explicit `try`/`catch` block with `Debugger.BreakForUserUnhandledException (Exception)`.

This entirely removes `JNINativeWrapper.CreateDelegate ()` and in turn `System.Reflection.Emit` from the marshal method codepath, which should improve app startup.

XA test PR: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10644574&view=results