### PR TITLE
[generator] Add `[UnmanagedFunctionPointer]` to marshal delegate declarations.

### DIFF
--- a/tests/generator-Tests/expected.xaji/AccessModifiers/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/AccessModifiers/__NamespaceMapping__.cs
@@ -3,6 +3,7 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/Adapters/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Adapters/__NamespaceMapping__.cs
@@ -3,7 +3,9 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PP_L (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/Android.Graphics.Color/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Android.Graphics.Color/__NamespaceMapping__.cs
@@ -3,7 +3,9 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PP_I (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPI_V (IntPtr jnienv, IntPtr klass, int p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/CSharpKeywords/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/CSharpKeywords/__NamespaceMapping__.cs
@@ -3,7 +3,9 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PP_L (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PPI_L (IntPtr jnienv, IntPtr klass, int p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/Core_Jar2Xml/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Core_Jar2Xml/__NamespaceMapping__.cs
@@ -4,7 +4,9 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "android.text", Managed="Android.Text")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PPL_I (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/GenericArguments/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/GenericArguments/__NamespaceMapping__.cs
@@ -3,8 +3,11 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "com.google.android.exoplayer.drm", Managed="Com.Google.Android.Exoplayer.Drm")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate bool _JniMarshal_PPL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPLLIIL_V (IntPtr jnienv, IntPtr klass, IntPtr p0, IntPtr p1, int p2, int p3, IntPtr p4);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/InterfaceMethodsConflict/__NamespaceMapping__.cs
@@ -3,6 +3,7 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/NestedTypes/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NestedTypes/__NamespaceMapping__.cs
@@ -3,6 +3,7 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PPI_L (IntPtr jnienv, IntPtr klass, int p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/NormalMethods/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NormalMethods/__NamespaceMapping__.cs
@@ -4,12 +4,19 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.util", Managed="Java.Util")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PP_I (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PP_L (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PPI_L (IntPtr jnienv, IntPtr klass, int p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPLIL_V (IntPtr jnienv, IntPtr klass, IntPtr p0, int p1, IntPtr p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PPLL_I (IntPtr jnienv, IntPtr klass, IntPtr p0, IntPtr p1);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/NormalProperties/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/NormalProperties/__NamespaceMapping__.cs
@@ -3,9 +3,13 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PP_I (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PP_L (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPI_V (IntPtr jnienv, IntPtr klass, int p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/ParameterXPath/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/ParameterXPath/__NamespaceMapping__.cs
@@ -4,6 +4,7 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.util", Managed="Java.Util")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "xamarin.test", Managed="Xamarin.Test")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/Streams/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/Streams/__NamespaceMapping__.cs
@@ -3,15 +3,25 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.io", Managed="Java.IO")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PP_I (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PP_L (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate bool _JniMarshal_PP_Z (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPI_V (IntPtr jnienv, IntPtr klass, int p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate long _JniMarshal_PPJ_J (IntPtr jnienv, IntPtr klass, long p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PPL_I (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PPLII_I (IntPtr jnienv, IntPtr klass, IntPtr p0, int p1, int p2);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPLII_V (IntPtr jnienv, IntPtr klass, IntPtr p0, int p1, int p2);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/TestInterface/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/TestInterface/__NamespaceMapping__.cs
@@ -5,11 +5,17 @@ using System;
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "test.me", Managed="Test.ME")]
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "", Managed="")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PP_L (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PP_V (IntPtr jnienv, IntPtr klass);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PPL_I (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate IntPtr _JniMarshal_PPL_L (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate void _JniMarshal_PPL_V (IntPtr jnienv, IntPtr klass, IntPtr p0);
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate bool _JniMarshal_PPL_Z (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tests/generator-Tests/expected.xaji/java.lang.Enum/__NamespaceMapping__.cs
+++ b/tests/generator-Tests/expected.xaji/java.lang.Enum/__NamespaceMapping__.cs
@@ -2,6 +2,7 @@ using System;
 
 [assembly:global::Android.Runtime.NamespaceMapping (Java = "java.lang", Managed="Java.Lang")]
 
+[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]
 delegate int _JniMarshal_PPL_I (IntPtr jnienv, IntPtr klass, IntPtr p0);
 #if !NET
 namespace System.Runtime.Versioning {

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/NamespaceMapping.cs
@@ -31,9 +31,12 @@ namespace MonoDroid.Generation
 					sw.WriteLine ();
 				}
 
+				// [UnmanagedFunctionPointer (CallingConvention.Winapi)]
 				// delegate bool _JniMarshal_PPL_Z (IntPtr jnienv, IntPtr klass, IntPtr a);
-				foreach (var jni in opt.GetJniMarshalDelegates ())
+				foreach (var jni in opt.GetJniMarshalDelegates ()) {
+					sw.WriteLine ("[global::System.Runtime.InteropServices.UnmanagedFunctionPointer (global::System.Runtime.InteropServices.CallingConvention.Winapi)]");
 					sw.WriteLine ($"delegate {FromJniType (jni[jni.Length - 1])} {jni} (IntPtr jnienv, IntPtr klass{GetDelegateParameters (jni)});");
+				}
 
 				// [SupportedOSPlatform] only exists in .NET 5.0+, so we need to generate a
 				// dummy one so earlier frameworks can compile.


### PR DESCRIPTION
Fixes: https://github.com/dotnet/java-interop/issues/1262
Context: 2197579478152fbc815eb15195977f808cd6bde4

> NativeAOT doesn't like this by default.  In order to convince
> NativeAOT to support this, every delegate instance provided to
> `JniNativeMethodRegistration.Delegate` must be of a delegate type
> which has [`UnmanagedFunctionPointerAttribute`][6].  This coerces
> NativeAOT to emit "stubs" for the referenced method, allowing things
> to work with fewer changes.
>
> [6]: https://learn.microsoft.com/dotnet/api/system.runtime.interopservices.unmanagedfunctionpointerattribute?view=net-8.0

For possible future NativeAOT support, every `_JniMarshal_*` delegate emitted by `generator` needs to have `[UnmanagedFunctionPointer]`, a'la:

```csharp
[UnmanagedFunctionPointer (CallingConvention.Winapi)]
delegate long _JniMarshal_PP_L (IntPtr env, IntPtr klass, long value);
```