### PR TITLE
[Java.Interop] remove `DynamicallyAccessedMemberTypes.Interfaces`

### DIFF
--- a/build-tools/trim-analyzers/trim-analyzers.props
+++ b/build-tools/trim-analyzers/trim-analyzers.props
@@ -1,0 +1,55 @@
+<!-- Import this to enable trim warnings of all kinds -->
+<Project>
+  <PropertyGroup>
+    <!-- Sets assembly metadata, enable analyzers -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <!-- In app projects, tells ILLink to emit warnings as errors -->
+    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+    <!--
+      Trim warnings, codes listed here:
+      * https://github.com/dotnet/runtime/blob/7403a062960d092c73ce3f07d3ff323ffdf7de43/src/tools/illink/src/linker/Resources/Strings.resx
+      * https://github.com/dotnet/docs/tree/9cb45cf9cd34f3b7259a023c3d92a124a87090d5/docs/core/deploying/trimming/trim-warnings
+    -->
+    <WarningsAsErrors>
+      $(WarningsAsErrors);
+      IL2000;IL2001;IL2002;IL2003;IL2004;
+      IL2005;IL2006;IL2007;IL2008;IL2009;
+      IL2010;IL2011;IL2012;IL2013;IL2014;
+      IL2015;IL2016;IL2017;IL2018;IL2019;
+      IL2020;IL2021;IL2022;IL2023;IL2024;
+      IL2025;IL2026;IL2027;IL2028;IL2029;
+      IL2030;IL2031;IL2032;IL2033;IL2034;
+      IL2035;IL2036;IL2037;IL2038;IL2039;
+      IL2040;IL2041;IL2042;IL2043;IL2044;
+      IL2045;IL2046;IL2047;IL2048;IL2049;
+      IL2050;IL2051;IL2052;IL2053;IL2054;
+      IL2055;IL2056;IL2057;IL2058;IL2059;
+      IL2060;IL2061;IL2062;IL2063;IL2064;
+      IL2065;IL2066;IL2067;IL2068;IL2069;
+      IL2070;IL2071;IL2072;IL2073;IL2074;
+      IL2075;IL2076;IL2077;IL2078;IL2079;
+      IL2080;IL2081;IL2082;IL2083;IL2084;
+      IL2085;IL2086;IL2087;IL2088;IL2089;
+      IL2090;IL2091;IL2092;IL2093;IL2094;
+      IL2095;IL2096;IL2097;IL2098;IL2099;
+      IL2100;IL2101;IL2102;IL2103;IL2104;
+      IL2105;IL2106;IL2107;IL2108;IL2109;
+      IL2110;IL2111;IL2112;IL2113;IL2114;
+      IL2115;IL2116;IL2117;IL2118;IL2119;
+      IL2120;IL2121;IL2122;IL2123;IL2124;
+      IL2125;IL2126;IL2127;IL2128;IL2129;
+    </WarningsAsErrors>
+    <!-- In NativeAOT app projects, tells Ilc to emit warnings as errors -->
+    <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>
+    <!--
+      NativeAOT warnings, codes listed here:
+      * https://github.com/dotnet/docs/tree/9cb45cf9cd34f3b7259a023c3d92a124a87090d5/docs/core/deploying/native-aot/warnings
+    -->
+    <WarningsAsErrors>
+      $(WarningsAsErrors);
+      IL3050;IL3051;IL3052;IL3053;IL3054;IL3055;IL3056;
+    </WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings.csproj
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings.csproj
@@ -3,13 +3,11 @@
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <DefineConstants>$(DefineConstants);JCW_ONLY_TYPE_NAMES;HAVE_CECIL</DefineConstants>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />
+  <Import Project="..\..\build-tools\trim-analyzers\trim-analyzers.props" />
   <Import Project="..\..\build-tools\scripts\cecil.projitems" />
 
   <ItemGroup>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -14,15 +14,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
-    <IsTrimmable>true</IsTrimmable>
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <MSBuildWarningsAsMessages>NU1702</MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <Import Project="..\..\TargetFrameworkDependentValues.props" />
+  <Import Project="..\..\build-tools\trim-analyzers\trim-analyzers.props" />
   <PropertyGroup>
     <DefineConstants>INTEROP;FEATURE_JNIOBJECTREFERENCE_INTPTRS;$(JavaInteropDefineConstants)</DefineConstants>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework.ToLowerInvariant())\</IntermediateOutputPath>

--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -363,7 +363,7 @@ namespace Java.Interop
 	}
 	
 	public abstract class JavaPrimitiveArray<
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			[DynamicallyAccessedMembers (Constructors)]
 			T
 	>
 		: JavaArray<T>

--- a/src/Java.Interop/Java.Interop/JavaObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaObject.cs
@@ -9,7 +9,6 @@ namespace Java.Interop
 	unsafe public class JavaObject : IJavaPeerable
 	{
 		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
-		internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = Constructors | DynamicallyAccessedMemberTypes.Interfaces;
 
 		readonly static JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (JavaObject));
 

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 namespace Java.Interop
 {
 	public class JavaObjectArray<
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			[DynamicallyAccessedMembers (Constructors)]
 			T
 	>
 		: JavaArray<T>
@@ -171,7 +171,7 @@ namespace Java.Interop
 			public override IList<T> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<T>.CreateValue (ref reference, options, targetType, (ref JniObjectReference h, JniObjectReferenceOptions t) => new JavaObjectArray<T> (ref h, t) {
@@ -203,7 +203,7 @@ namespace Java.Interop
 		partial class Arrays {
 
 			public static JavaObjectArray<T>? CreateMarshalObjectArray<
-					[DynamicallyAccessedMembers (JavaObject.ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (JavaObject.Constructors)]
 					T
 			> (
 					IEnumerable<T>? value)

--- a/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
+++ b/src/Java.Interop/Java.Interop/JavaPrimitiveArrays.cs
@@ -246,7 +246,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -257,7 +257,7 @@ namespace Java.Interop {
 			public override IList<Boolean> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Boolean>.CreateValue (
@@ -450,7 +450,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -461,7 +461,7 @@ namespace Java.Interop {
 			public override IList<SByte> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<SByte>.CreateValue (
@@ -654,7 +654,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -665,7 +665,7 @@ namespace Java.Interop {
 			public override IList<Char> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Char>.CreateValue (
@@ -858,7 +858,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -869,7 +869,7 @@ namespace Java.Interop {
 			public override IList<Int16> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Int16>.CreateValue (
@@ -1062,7 +1062,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1073,7 +1073,7 @@ namespace Java.Interop {
 			public override IList<Int32> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Int32>.CreateValue (
@@ -1266,7 +1266,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1277,7 +1277,7 @@ namespace Java.Interop {
 			public override IList<Int64> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Int64>.CreateValue (
@@ -1470,7 +1470,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1481,7 +1481,7 @@ namespace Java.Interop {
 			public override IList<Single> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Single>.CreateValue (
@@ -1674,7 +1674,7 @@ namespace Java.Interop {
 
 		public static object? CreateMarshaledValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return ArrayMarshaler.CreateValue (handle, targetType);
@@ -1685,7 +1685,7 @@ namespace Java.Interop {
 			public override IList<Double> CreateGenericValue (
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions options,
-					[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+					[DynamicallyAccessedMembers (Constructors)]
 					Type? targetType)
 			{
 				return JavaArray<Double>.CreateValue (

--- a/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
+++ b/src/Java.Interop/Java.Interop/JniBuiltinMarshalers.cs
@@ -226,7 +226,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -237,7 +237,7 @@ namespace Java.Interop {
 		public override Boolean CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -299,7 +299,7 @@ namespace Java.Interop {
 		public override Boolean? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -370,7 +370,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -381,7 +381,7 @@ namespace Java.Interop {
 		public override SByte CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -443,7 +443,7 @@ namespace Java.Interop {
 		public override SByte? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -514,7 +514,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -525,7 +525,7 @@ namespace Java.Interop {
 		public override Char CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -587,7 +587,7 @@ namespace Java.Interop {
 		public override Char? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -658,7 +658,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -669,7 +669,7 @@ namespace Java.Interop {
 		public override Int16 CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -731,7 +731,7 @@ namespace Java.Interop {
 		public override Int16? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -802,7 +802,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -813,7 +813,7 @@ namespace Java.Interop {
 		public override Int32 CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -875,7 +875,7 @@ namespace Java.Interop {
 		public override Int32? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -946,7 +946,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -957,7 +957,7 @@ namespace Java.Interop {
 		public override Int64 CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1019,7 +1019,7 @@ namespace Java.Interop {
 		public override Int64? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1090,7 +1090,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1101,7 +1101,7 @@ namespace Java.Interop {
 		public override Single CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1163,7 +1163,7 @@ namespace Java.Interop {
 		public override Single? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1234,7 +1234,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1245,7 +1245,7 @@ namespace Java.Interop {
 		public override Double CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)
@@ -1307,7 +1307,7 @@ namespace Java.Interop {
 		public override Double? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			if (!reference.IsValid)

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -200,7 +200,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			throw new NotSupportedException ();
@@ -209,7 +209,7 @@ namespace Java.Interop {
 		public override IntPtr CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			throw new NotSupportedException ();

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniMarshalMemberBuilder.cs
@@ -142,12 +142,6 @@ namespace Java.Interop {
 
 			public JniValueMarshaler GetParameterMarshaler (ParameterInfo parameter)
 			{
-				// Activator.CreateInstance requires DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
-				// GetValueMarshaler requires DynamicallyAccessedMemberTypes.Interfaces
-				[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "JniValueMarshalerAttribute is decorated with [DynamicallyAccessedMembers]")]
-				static JniValueMarshaler GetValueMarshaler (JniValueManager manager, ParameterInfo parameter) =>
-					manager.GetValueMarshaler (parameter.ParameterType);
-
 				if (parameter.ParameterType == typeof (IntPtr))
 					return IntPtrValueMarshaler.Instance;
 
@@ -160,7 +154,7 @@ namespace Java.Interop {
 				if (attr != null) {
 					return (JniValueMarshaler) Activator.CreateInstance (attr.MarshalerType)!;
 				}
-				return GetValueMarshaler (Runtime.ValueManager, parameter);
+				return Runtime.ValueManager.GetValueMarshaler (parameter.ParameterType);
 			}
 
 			// Heuristic: if first two parameters are IntPtr, this is a "direct" wrapper.

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -83,7 +83,7 @@ namespace Java.Interop {
 
 			internal const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods;
 			internal const DynamicallyAccessedMemberTypes MethodsAndPrivateNested = Methods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes;
-			internal const DynamicallyAccessedMemberTypes MethodsConstructorsInterfaces = MethodsAndPrivateNested | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+			internal const DynamicallyAccessedMemberTypes MethodsConstructors = MethodsAndPrivateNested | DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 			JniRuntime?             runtime;
 			bool                    disposed;
@@ -285,7 +285,7 @@ namespace Java.Interop {
 				#pragma warning restore IL3050
 
 			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
-			[return: DynamicallyAccessedMembers (MethodsConstructorsInterfaces)]
+			[return: DynamicallyAccessedMembers (MethodsConstructors)]
 			public  Type?    GetType (JniTypeSignature typeSignature)
 			{
 				AssertValid ();

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -898,16 +898,12 @@ namespace Java.Interop
 
 		public override JniValueMarshalerState CreateGenericObjectReferenceArgumentState ([MaybeNull]object? value, ParameterAttributes synchronize)
 		{
-			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "This code path is not used in Android projects.")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.Interfaces)]
-			static Type GetType (object value) => value.GetType ();
-
 			if (value == null)
 				return new JniValueMarshalerState ();
 
 			var jvm     = JniEnvironment.Runtime;
 
-			var vm      = jvm.ValueManager.GetValueMarshaler (GetType (value));
+			var vm      = jvm.ValueManager.GetValueMarshaler (value.GetType ());
 			if (vm != Instance) {
 				var s   = vm.CreateObjectReferenceArgumentState (value, synchronize);
 				return new JniValueMarshalerState (s, vm);

--- a/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniStringValueMarshaler.cs
@@ -17,7 +17,7 @@ namespace Java.Interop {
 		public override string? CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			return JniEnvironment.Strings.ToString (ref reference, options, targetType ?? typeof (string));

--- a/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshaler.cs
@@ -120,7 +120,7 @@ namespace Java.Interop {
 
 	public abstract class JniValueMarshaler {
 
-		internal const DynamicallyAccessedMemberTypes ConstructorsAndInterfaces = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces;
+		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 		internal const string ExpressionRequiresUnreferencedCode = "System.Linq.Expression usage may trim away required code.";
 
 		public  virtual     bool                    IsJniValueType {
@@ -135,7 +135,7 @@ namespace Java.Interop {
 		public  abstract    object?                 CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateArgumentState (object? value, ParameterAttributes synchronize = 0)
@@ -148,7 +148,7 @@ namespace Java.Interop {
 
 		internal object? CreateValue (
 				IntPtr handle,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType)
 		{
 			var r = new JniObjectReference (handle);
@@ -236,7 +236,7 @@ namespace Java.Interop {
 	}
 
 	public abstract class JniValueMarshaler<
-			[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+			[DynamicallyAccessedMembers (Constructors)]
 			T
 	>
 		: JniValueMarshaler
@@ -246,7 +246,7 @@ namespace Java.Interop {
 		public  abstract    T                       CreateGenericValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null);
 
 		public  virtual     JniValueMarshalerState  CreateGenericArgumentState ([MaybeNull] T value, ParameterAttributes synchronize = 0)
@@ -260,7 +260,7 @@ namespace Java.Interop {
 		public override object? CreateValue (
 				ref JniObjectReference reference,
 				JniObjectReferenceOptions options,
-				[DynamicallyAccessedMembers (ConstructorsAndInterfaces)]
+				[DynamicallyAccessedMembers (Constructors)]
 				Type? targetType = null)
 		{
 			return CreateGenericValue (ref reference, options, targetType ?? typeof (T));

--- a/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
+++ b/src/Java.Interop/Java.Interop/JniValueMarshalerAttribute.cs
@@ -8,7 +8,7 @@ namespace Java.Interop {
 
 	[AttributeUsage (Targets, AllowMultiple=false)]
 	public class JniValueMarshalerAttribute : Attribute {
-		const DynamicallyAccessedMemberTypes ParameterlessConstructorsInterfaces = DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces;
+		const DynamicallyAccessedMemberTypes ParameterlessConstructors = DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
 
 		const   AttributeTargets    Targets =
 			AttributeTargets.Class | AttributeTargets.Enum |
@@ -16,7 +16,7 @@ namespace Java.Interop {
 			AttributeTargets.Parameter | AttributeTargets.ReturnValue;
 
 		public JniValueMarshalerAttribute (
-				[DynamicallyAccessedMembers (ParameterlessConstructorsInterfaces)]
+				[DynamicallyAccessedMembers (ParameterlessConstructors)]
 				Type marshalerType)
 		{
 			if (marshalerType == null)
@@ -29,7 +29,7 @@ namespace Java.Interop {
 			MarshalerType   = marshalerType;
 		}
 
-		[DynamicallyAccessedMembers (ParameterlessConstructorsInterfaces)]
+		[DynamicallyAccessedMembers (ParameterlessConstructors)]
 		public  Type    MarshalerType   {
 			get;
 		}


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9630

As #9630 required new declarations of
`DynamicallyAccessedMemberTypes.Interfaces`, we intestigated to see *why* these were needed in Java.Interop.

There are two cases:

    var listIface   = typeof (IList<>);
    var listType    =
        (from iface in type.GetInterfaces ().Concat (new[]{type})
            where (listIface).IsAssignableFrom (iface.IsGenericType ? iface.GetGenericTypeDefinition () : iface)
            select iface)
        .FirstOrDefault ();

This first one, if `IList<>` were trimmed away. We don't actually care, as everything in this code path would still work. We can suppress the warning instead.

The second case:

    JniValueMarshalerAttribute? ifaceAttribute = null;
    foreach (var iface in type.GetInterfaces ()) {
        marshalerAttr = iface.GetCustomAttribute<JniValueMarshalerAttribute> ();
        if (marshalerAttr != null) {
            if (ifaceAttribute != null)
                throw new NotSupportedException ($"There is more than one interface with custom marshaler for type {type}.");

            ifaceAttribute = marshalerAttr;
        }
    }
    if (ifaceAttribute != null)
        return (JniValueMarshaler) Activator.CreateInstance (ifaceAttribute.MarshalerType)!;

Feels like we should be able to remove this code completely.

With these changes we can remove `DynamicallyAccessedMemberTypes.Interfaces`.

I also introduced `build-tools/trim-analyzers/trim-analyzers.props` that will setup the appropriate trimmer MSBuild properties to make trimmer warnings an error. This should keep us from accidentally creating warnings. I only use this setting in projects that were already using `$(EnableAotAnalyzer)`.