### PR TITLE
[Tools.JavaSource] Support html tags with attributes

### DIFF
--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -63,10 +63,10 @@ namespace Java.Interop.Tools.JavaSource {
 				};
 
 				var fontstyle_tt    = CreateHtmlToCrefElement (grammar, "tt",   "c", InlineDeclarations, optionalEnd: true);
-				var fontstyle_i     = CreateHtmlToCrefElement (grammar, "i",    "i", InlineDeclarations, optionalEnd: true, ignoreAttributes: true);
+				var fontstyle_i     = CreateHtmlToCrefElement (grammar, "i",    "i", InlineDeclarations, optionalEnd: true);
 
 				var preText = new PreBlockDeclarationBodyTerminal ();
-				PreBlockDeclaration.Rule = CreateStartElementIgnoreAttribute ("pre") + preText + CreateEndElement ("pre", grammar, optional: true);
+				PreBlockDeclaration.Rule = CreateStartElement ("pre") + preText + CreateEndElement ("pre", grammar, optional: true);
 				PreBlockDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
 					if (!grammar.ShouldImport (ImportJavadoc.Remarks)) {
 						parseNode.AstNode   = "";
@@ -82,7 +82,7 @@ namespace Java.Interop.Tools.JavaSource {
 				FontStyleDeclaration.Rule = fontstyle_tt | fontstyle_i;
 
 				PBlockDeclaration.Rule =
-					CreateStartElement ("p", grammar) + InlineDeclarations + CreateEndElement ("p", grammar, optional:true)
+					CreateStartElement ("p") + InlineDeclarations + CreateEndElement ("p", grammar, optional:true)
 					;
 				PBlockDeclaration.AstConfig.NodeCreator = (context, parseNode) => {
 					var remarks     = FinishParse (context, parseNode).Remarks;
@@ -258,12 +258,9 @@ namespace Java.Interop.Tools.JavaSource {
 				},
 			};
 
-			static NonTerminal CreateHtmlToCrefElement (Grammar grammar, string htmlElement, string crefElement, BnfTerm body, bool optionalEnd = false, bool ignoreAttributes = false)
+			static NonTerminal CreateHtmlToCrefElement (Grammar grammar, string htmlElement, string crefElement, BnfTerm body, bool optionalEnd = false)
 			{
-				BnfTerm start   = CreateStartElement (htmlElement, grammar);
-				if (ignoreAttributes) {
-					start = CreateStartElementIgnoreAttribute (htmlElement);
-				}
+				var start       = CreateStartElement (htmlElement);
 				var end         = CreateEndElement (htmlElement, grammar, optionalEnd);
 				var nonTerminal = new NonTerminal ("<" + htmlElement + ">", ConcatChildNodes) {
 					Rule = start + body + end,
@@ -278,26 +275,13 @@ namespace Java.Interop.Tools.JavaSource {
 				return nonTerminal;
 			}
 
-			static NonTerminal CreateStartElement (string startElement, Grammar grammar)
+			static RegexBasedTerminal CreateStartElement (string startElement, string attribute = "")
 			{
-				var start   = new NonTerminal ("<" + startElement + ">", nodeCreator: (context, parseNode) => parseNode.AstNode = "") {
-					Rule    = grammar.ToTerm ("<" + startElement + ">") | "<" + startElement.ToUpperInvariant () + ">",
-				};
-				return start;
-			}
-
-			static RegexBasedTerminal CreateStartElementIgnoreAttribute (string startElement, string attribute)
-			{
-				return new RegexBasedTerminal ($"<{startElement} {attribute}", $@"(?i)<\b{startElement}\b\s*{attribute}[^>]*>") {
+				return new RegexBasedTerminal ($"<{startElement} {attribute}>", $@"(?i)<\b{startElement}\b\s*{attribute}[^>]*>") {
 					AstConfig = new AstNodeConfig {
 						NodeCreator = (context, parseNode) => parseNode.AstNode = "",
 					},
 				};
-			}
-
-			static RegexBasedTerminal CreateStartElementIgnoreAttribute (string startElement)
-			{
-				return CreateStartElementIgnoreAttribute (startElement, "");
 			}
 
 			static NonTerminal CreateEndElement (string endElement, Grammar grammar, bool optional = false)

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource/SourceJavadocToXmldocGrammar.HtmlBnfTerms.cs
@@ -63,7 +63,7 @@ namespace Java.Interop.Tools.JavaSource {
 				};
 
 				var fontstyle_tt    = CreateHtmlToCrefElement (grammar, "tt",   "c", InlineDeclarations, optionalEnd: true);
-				var fontstyle_i     = CreateHtmlToCrefElement (grammar, "i",    "i", InlineDeclarations, optionalEnd: true);
+				var fontstyle_i     = CreateHtmlToCrefElement (grammar, "i",    "i", InlineDeclarations, optionalEnd: true, ignoreAttributes: true);
 
 				var preText = new PreBlockDeclarationBodyTerminal ();
 				PreBlockDeclaration.Rule = CreateStartElementIgnoreAttribute ("pre") + preText + CreateEndElement ("pre", grammar, optional: true);
@@ -258,9 +258,12 @@ namespace Java.Interop.Tools.JavaSource {
 				},
 			};
 
-			static NonTerminal CreateHtmlToCrefElement (Grammar grammar, string htmlElement, string crefElement, BnfTerm body, bool optionalEnd = false)
+			static NonTerminal CreateHtmlToCrefElement (Grammar grammar, string htmlElement, string crefElement, BnfTerm body, bool optionalEnd = false, bool ignoreAttributes = false)
 			{
-				var start       = CreateStartElement (htmlElement, grammar);
+				BnfTerm start   = CreateStartElement (htmlElement, grammar);
+				if (ignoreAttributes) {
+					start = CreateStartElementIgnoreAttribute (htmlElement);
+				}
 				var end         = CreateEndElement (htmlElement, grammar, optionalEnd);
 				var nonTerminal = new NonTerminal ("<" + htmlElement + ">", ConcatChildNodes) {
 					Rule = start + body + end,
@@ -285,7 +288,7 @@ namespace Java.Interop.Tools.JavaSource {
 
 			static RegexBasedTerminal CreateStartElementIgnoreAttribute (string startElement, string attribute)
 			{
-				return new RegexBasedTerminal ($"<{startElement} {attribute}", $@"(?i)<{startElement}\s*{attribute}[^>]*>") {
+				return new RegexBasedTerminal ($"<{startElement} {attribute}", $@"(?i)<\b{startElement}\b\s*{attribute}[^>]*>") {
 					AstConfig = new AstNodeConfig {
 						NodeCreator = (context, parseNode) => parseNode.AstNode = "",
 					},

--- a/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
+++ b/tests/Java.Interop.Tools.JavaSource-Tests/SourceJavadocToXmldocGrammar.HtmlBnfTermsTests.cs
@@ -34,6 +34,10 @@ namespace Java.Interop.Tools.JavaSource.Tests
 			r = p.Parse("<p>r= <em>unknown</em> text");
 			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
 			Assert.AreEqual ("<para>r= &lt;em&gt;unknown&lt;/em&gt; text</para>", r.Root.AstNode.ToString ());
+
+			r = p.Parse ("<p>For <li>A <i id=\"deviceowner\">Device Owner</i>");
+			Assert.IsFalse (r.HasErrors (), DumpMessages (r, p));
+			Assert.AreEqual ("<para>For &lt;li&gt;A <i>Device Owner</i></para>", r.Root.AstNode.ToString ());
 		}
 
 		[Test]


### PR DESCRIPTION
A recent attempt to import API docs for API 35 produced the following:

    The following issues were found, review the build log for more details:
    >   ## Unable to translate remarks for android/app/admin/DevicePolicyManager:
    >   JavadocImport-Error (31:39): Syntax error, expected: </p>, </P>, #PCDATA, <tt>, <TT>, <i>, <I>, <a attr=, <code>, {@code, {@docRoot}, {@inheritDoc}, {@link, {@linkplain, {@literal, {@see, {@value}, {@value, IgnorableDeclaration, {@param, UnknownHtmlElementStart, <p>, <P>, <pre , @author, @apiSince, @deprecated, @deprecatedSince, @exception, @inheritDoc, @hide, @param, @return, @see, @serialData, @serialField, @since, @throws, @[unknown], @version
        <li>A <i id="deviceowner">Device Owner</i>, which only ever exists on the
                                              ^

Parsing logic fails here because the `<i>` tag has an `id` attribute _and_ is present in an open `<p>` tag:

    ParserTrace:
      input=`<p> (Key symbol)`; error? False; message=Shift to S3
      input=``; error? False; message=Reduce on '<p> -> <p> '
      input=`<p>`; error? False; message=Popped state from stack, pushing <p>
      input=`For  (#PCDATA)`; error? False; message=Shift to S10
      input=``; error? False; message=Reduce on '<html inline decl> -> #PCDATA '
      input=`<html inline decl>`; error? False; message=Popped state from stack, pushing <html inline decl>
      input=``; error? False; message=Reduce on 'InlineDeclaration -> <html inline decl> '
      input=`InlineDeclaration`; error? False; message=Popped state from stack, pushing InlineDeclaration
      input=``; error? False; message=Reduce on 'InlineDeclaration+ -> InlineDeclaration '
      input=`InlineDeclaration+`; error? False; message=Popped state from stack, pushing InlineDeclaration+
      input=`< (UnknownHtmlElementStart)`; error? False; message=Shift to S45
      input=``; error? False; message=Reduce on '<html inline decl> -> UnknownHtmlElementStart '
      input=`<html inline decl>`; error? False; message=Popped state from stack, pushing <html inline decl>
      input=``; error? False; message=Reduce on 'InlineDeclaration -> <html inline decl> '
      input=`InlineDeclaration`; error? False; message=Popped state from stack, pushing InlineDeclaration
      input=``; error? False; message=Reduce on 'InlineDeclaration+ -> InlineDeclaration+ InlineDeclaration '
      input=`InlineDeclaration+`; error? False; message=Popped state from stack, pushing InlineDeclaration+
      input=`li>A  (#PCDATA)`; error? False; message=Shift to S10
      input=``; error? False; message=Reduce on '<html inline decl> -> #PCDATA '
      input=`<html inline decl>`; error? False; message=Popped state from stack, pushing <html inline decl>
      input=``; error? False; message=Reduce on 'InlineDeclaration -> <html inline decl> '
      input=`InlineDeclaration`; error? False; message=Popped state from stack, pushing InlineDeclaration
      input=``; error? False; message=Reduce on 'InlineDeclaration+ -> InlineDeclaration+ InlineDeclaration '
      input=`InlineDeclaration+`; error? False; message=Popped state from stack, pushing InlineDeclaration+
      input=`< (UnknownHtmlElementStart)`; error? False; message=Shift to S45
      input=``; error? False; message=Reduce on '<html inline decl> -> UnknownHtmlElementStart '
      input=`<html inline decl>`; error? False; message=Popped state from stack, pushing <html inline decl>
      input=``; error? False; message=Reduce on 'InlineDeclaration -> <html inline decl> '
      input=`InlineDeclaration`; error? False; message=Popped state from stack, pushing InlineDeclaration
      input=``; error? False; message=Reduce on 'InlineDeclaration+ -> InlineDeclaration+ InlineDeclaration '
      input=`InlineDeclaration+`; error? False; message=Popped state from stack, pushing InlineDeclaration+
      input=`i id="deviceowner">Device Owner (#PCDATA)`; error? False; message=Shift to S10
      input=``; error? False; message=Reduce on '<html inline decl> -> #PCDATA '
      input=`<html inline decl>`; error? False; message=Popped state from stack, pushing <html inline decl>
      input=``; error? False; message=Reduce on 'InlineDeclaration -> <html inline decl> '
      input=`InlineDeclaration`; error? False; message=Popped state from stack, pushing InlineDeclaration
      input=``; error? False; message=Reduce on 'InlineDeclaration+ -> InlineDeclaration+ InlineDeclaration '
      input=`InlineDeclaration+`; error? False; message=Popped state from stack, pushing InlineDeclaration+
      input=`</i> (Key symbol)`; error? False; message=Reduce on 'InlineDeclarations -> InlineDeclaration+ '
      input=`InlineDeclarations`; error? False; message=Popped state from stack, pushing InlineDeclarations
      input=`</i> (Key symbol)`; error? True; message=Syntax error, expected: </p>, </P>
      input=`</i> (Key symbol)`; error? False; message=RECOVERING: popping stack, looking for state with error shift
      input=`</i> (Key symbol)`; error? False; message=FAILED TO RECOVER

Updates the grammar to ignore attributes on html tags such as `<x y=z>` to fix this.

The regex in `CreateStartElement` has also been improved to include word boundaries around the tag name to make sure that it does not match unexpected elements.