### PR TITLE
[ci] Fail build if any git tracked files were modified.

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -61,6 +61,8 @@ jobs:
       nativeAotRid: win-x64
       platformName: .NET - Windows
 
+  - template: templates\fail-on-dirty-tree.yaml
+
   - template: templates\fail-on-issue.yaml
 
   - task: PublishPipelineArtifact@1
@@ -91,6 +93,8 @@ jobs:
       runNativeTests: true
       nativeAotRid: osx-x64
       platformName: .NET - MacOS
+
+  - template: templates\fail-on-dirty-tree.yaml
 
   - template: templates\fail-on-issue.yaml
 

--- a/build-tools/automation/templates/fail-on-dirty-tree.yaml
+++ b/build-tools/automation/templates/fail-on-dirty-tree.yaml
@@ -1,0 +1,22 @@
+# Ensure the build did not produce any modified checked in files
+
+parameters:
+  condition: succeeded()
+
+steps:
+- powershell: |
+    # Run this to log the output for the user
+    git status
+
+    # Run this to error the build if untracked files
+    $process= git status --porcelain --untracked-files=no
+
+    if ($process)
+    {
+        Write-Host "##vso[task.logissue type=error]git tree has modified tracked files."
+        Write-Host "##vso[task.complete result=Failed;]"
+    }
+    
+    git diff
+  displayName: Ensure no modified committed files
+  condition: ${{ parameters.condition }}

--- a/src/Java.Base/Java.Base.targets
+++ b/src/Java.Base/Java.Base.targets
@@ -84,4 +84,18 @@
     </PropertyGroup>
   </Target>
 
+  <!--
+    The <GenAPITask/> task always generates files with WIndows line endings,
+    which causes `git status` to show the file as modified.
+
+    Update `$(GenAPITargetPath)` so that it contains Unix line endings..
+    -->
+  <Target Name="_FixGenApiLineEndings"
+      Condition=" !$([MSBuild]::IsOSPlatform ('windows')) "
+      AfterTargets="GenerateReferenceAssemblySource">
+    <Move SourceFiles="$(GenAPITargetPath)" DestinationFiles="$(GenAPITargetPath).crlf" />
+    <Exec Command="tr -d '\015' &lt; $(GenAPITargetPath).crlf > $(GenAPITargetPath)" />
+    <Delete Files="$(GenAPITargetPath).crlf" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9661

Scenarios where the build unintentionally modifies git tracked files on some platforms are frustrating, so let's prevent them from happening in the first place.

Add a CI check to fail a build if any git tracked files were modified.

Also contains a fix for `<GenAPITask/>` task always generates files with Windows line endings, which causes `git status` to show the file as modified on other platforms.