### PR TITLE
[build] Prefer JDK-17

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,7 +62,7 @@
     <JavacSourceVersion Condition=" '$(JavacSourceVersion)' == '' ">11</JavacSourceVersion>
     <JavacTargetVersion Condition=" '$(JavacTargetVersion)' == '' ">11</JavacTargetVersion>
     <_BootClassPath Condition=" '$(JreRtJarPath)' != '' ">-bootclasspath "$(JreRtJarPath)"</_BootClassPath>
-    <_JavacSourceOptions>-source $(JavacSourceVersion) -target $(JavacTargetVersion) $(_BootClassPath)</_JavacSourceOptions>
+    <_JavacSourceOptions>--release $(JavacTargetVersion) $(_BootClassPath)</_JavacSourceOptions>
   </PropertyGroup>
   <PropertyGroup>
     <XamarinAndroidToolsFullPath>$([System.IO.Path]::GetFullPath ('$(XamarinAndroidToolsDirectory)'))</XamarinAndroidToolsFullPath>

--- a/build-tools/scripts/Prepare.targets
+++ b/build-tools/scripts/Prepare.targets
@@ -15,8 +15,8 @@
     <PropertyGroup>
       <_MaxJdk>$(MaxJdkVersion)</_MaxJdk>
       <_MaxJdk Condition=" '$(_MaxJdk)' == '' ">$(JI_MAX_JDK)</_MaxJdk>
-      <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</JdksRoot>
       <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_17_X64)' != '' And Exists($(JAVA_HOME_17_X64)) ">$(JAVA_HOME_17_X64)</JdksRoot>
+      <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</JdksRoot>
     </PropertyGroup>
     <JdkInfo
         JdksRoot="$(JdksRoot)"

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaEnumTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaEnumTests.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 53,
+				ConstantPoolCount   = 55,
 				AccessFlags         = ClassAccessFlags.Final | ClassAccessFlags.Super | ClassAccessFlags.Enum,
 				FullName            = "com/xamarin/JavaEnum",
 				Superclass          = new TypeInfo ("java/lang/Enum",   "Ljava/lang/Enum<Lcom/xamarin/JavaEnum;>;"),
@@ -70,6 +70,11 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						Name                    = "switchValue",
 						AccessFlags             = MethodAccessFlags.Public,
 						ReturnDescriptor        = "I",
+					},
+					new ExpectedMethodDeclaration {
+						Name                    = "$values",
+						AccessFlags             = MethodAccessFlags.Private | MethodAccessFlags.Static | MethodAccessFlags.Synthetic,
+						ReturnDescriptor        = "[Lcom/xamarin/JavaEnum;",
 					},
 					new ExpectedMethodDeclaration {
 						Name                    = "<clinit>",

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/JavaTypeTests.cs
@@ -36,6 +36,12 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 				},
 				InnerClasses = {
 					new ExpectedInnerClassInfo {
+						InnerClassName  = "com/xamarin/JavaType$1",
+						OuterClassName  = null,
+						InnerName       = null,
+						AccessFlags     = 0,
+					},
+					new ExpectedInnerClassInfo {
 						InnerClassName  = "com/xamarin/JavaType$ASC",
 						OuterClassName  = "com/xamarin/JavaType",
 						InnerName       = "ASC",
@@ -57,12 +63,6 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						InnerClassName  = "com/xamarin/JavaType$1MyStringList",
 						OuterClassName  = null,
 						InnerName       = "MyStringList",
-						AccessFlags     = 0,
-					},
-					new ExpectedInnerClassInfo {
-						InnerClassName  = "com/xamarin/JavaType$1",
-						OuterClassName  = null,
-						InnerName       = null,
 						AccessFlags     = 0,
 					},
 					new ExpectedInnerClassInfo {
@@ -149,7 +149,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 						Name                = "STATIC_FINAL_STRING",
 						Descriptor          = "Ljava/lang/String;",
 						AccessFlags         = FieldAccessFlags.Public | FieldAccessFlags.Static | FieldAccessFlags.Final,
-						ConstantValue       = "String(stringIndex=190 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
+						ConstantValue       = "String(stringIndex=101 Utf8=\"Hello, \\\"embedded\0Nulls\" and \ud83d\udca9!\")",
 					},
 					new ExpectedFieldDeclaration {
 						Name                = "STATIC_FINAL_BOOL_FALSE",

--- a/tests/Xamarin.Android.Tools.Bytecode-Tests/ModuleInfoTests.cs
+++ b/tests/Xamarin.Android.Tools.Bytecode-Tests/ModuleInfoTests.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Android.Tools.BytecodeTests {
 			new ExpectedTypeDeclaration {
 				MajorVersion        = 0x37,
 				MinorVersion        = 0,
-				ConstantPoolCount   = 13,
+				ConstantPoolCount   = 12,
 				AccessFlags         = ClassAccessFlags.Module,
 				FullName            = "module-info",
 			}.Assert (c);

--- a/tools/java-source-utils/src/test/java/com/microsoft/android/JavaSourceUtilsOptionsTest.java
+++ b/tools/java-source-utils/src/test/java/com/microsoft/android/JavaSourceUtilsOptionsTest.java
@@ -9,8 +9,6 @@ import java.io.*;
 
 import org.junit.Test;
 
-import jdk.nashorn.internal.AssertsEnabled;
-
 import static org.junit.Assert.*;
 
 public class JavaSourceUtilsOptionsTest {

--- a/tools/java-source-utils/src/test/java/com/microsoft/android/JavadocXmlGeneratorTest.java
+++ b/tools/java-source-utils/src/test/java/com/microsoft/android/JavadocXmlGeneratorTest.java
@@ -99,9 +99,12 @@ public final class JavadocXmlGeneratorTest {
 
 		generator.writePackages(packagesInfo);
 		generator.close();
-		// try (FileOutputStream o = new FileOutputStream(assertDescription + "-jonp.xml")) {
-		// 	bytes.writeTo(o);
-		// }
+
+		final   File                    actual          = new File(assertDescription + "-jonp.xml");
+		try (FileOutputStream o = new FileOutputStream(actual)) {
+			bytes.writeTo(o);
+		}
 		assertEquals(assertDescription, expected, bytes.toString());
+		actual.delete();
 	}
 }

--- a/tools/java-source-utils/src/test/resources/UnresolvedTypes.xml
+++ b/tools/java-source-utils/src/test/resources/UnresolvedTypes.xml
@@ -4,11 +4,9 @@
     <class jni-signature="Lexample/UnresolvedTypes;" name="UnresolvedTypes">
       <method jni-return="L.*UnresolvedReturnType;" jni-signature="([L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;" name="method" return=".*UnresolvedReturnType">
         <parameter jni-type="[L.*example.name.UnresolvedParameterType;" name="parameter" type=".*example.name.UnresolvedParameterType..."/>
-        <javadoc>
-          <![CDATA[Method using unresolvable types.  As such, we make do.
+        <javadoc><![CDATA[Method using unresolvable types.  As such, we make do.
 
-JNI Sig: method.([L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;]]>
-        </javadoc>
+JNI Sig: method.([L.*example.name.UnresolvedParameterType;)L.*UnresolvedReturnType;]]></javadoc>
       </method>
     </class>
   </package>

--- a/tools/java-source-utils/src/test/resources/com/microsoft/android/DemoInfo.xml
+++ b/tools/java-source-utils/src/test/resources/com/microsoft/android/DemoInfo.xml
@@ -2,57 +2,39 @@
 <api api-source="java-source-utils">
   <package jni-name="" name="">
     <class jni-signature="LA;" name="A">
-      <javadoc>
-        <![CDATA[jni-sig=LA;]]>
-      </javadoc>
+      <javadoc><![CDATA[jni-sig=LA;]]></javadoc>
       <constructor jni-signature="(ILjava/lang/String;)V">
         <parameter jni-type="I" name="one" type="int"/>
         <parameter jni-type="Ljava/lang/String;" name="two" type="java.lang.String"/>
-        <javadoc>
-          <![CDATA[jni-sig=<init>.(ILjava/lang/String;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[jni-sig=<init>.(ILjava/lang/String;)V]]></javadoc>
       </constructor>
       <field jni-signature="I" name="field">
-        <javadoc>
-          <![CDATA[jni-sig=field.I]]>
-        </javadoc>
+        <javadoc><![CDATA[jni-sig=field.I]]></javadoc>
       </field>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;J)V" name="m" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="T"/>
         <parameter jni-type="J" name="x" type="long"/>
-        <javadoc>
-          <![CDATA[jni-sig=m.(Ljava/lang/Object;J)V]]>
-        </javadoc>
+        <javadoc><![CDATA[jni-sig=m.(Ljava/lang/Object;J)V]]></javadoc>
       </method>
     </class>
     <interface jni-signature="LI;" name="I">
-      <javadoc>
-        <![CDATA[jni-sig=LI;]]>
-      </javadoc>
+      <javadoc><![CDATA[jni-sig=LI;]]></javadoc>
       <method jni-return="Ljava/lang/Object;" jni-signature="(Ljava/util/List;)Ljava/lang/Object;" name="m" return="T">
         <parameter jni-type="Ljava/util/List;" name="x" type="java.util.List&lt;T&gt;"/>
-        <javadoc>
-          <![CDATA[jni-sig=m.(Ljava/util/List;)Ljava/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[jni-sig=m.(Ljava/util/List;)Ljava/lang/Object;]]></javadoc>
       </method>
     </interface>
   </package>
   <package jni-name="before/example" name="before.example"/>
   <package jni-name="example" name="example">
     <interface jni-signature="Lexample/Exampleable;" name="Exampleable">
-      <javadoc>
-        <![CDATA[jni-sig=Lexample/Exampleable;]]>
-      </javadoc>
+      <javadoc><![CDATA[jni-sig=Lexample/Exampleable;]]></javadoc>
       <method jni-return="V" jni-signature="(Ljava/lang/String;)V" name="example" return="void">
         <parameter jni-type="Ljava/lang/String;" name="e" type="java.lang.String"/>
-        <javadoc>
-          <![CDATA[jni-sig=example.(Ljava/lang/String;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[jni-sig=example.(Ljava/lang/String;)V]]></javadoc>
       </method>
       <method jni-return="V" jni-signature="()V" name="noParameters" return="void">
-        <javadoc>
-          <![CDATA[jni-sig=noParameters.()V]]>
-        </javadoc>
+        <javadoc><![CDATA[jni-sig=noParameters.()V]]></javadoc>
       </method>
     </interface>
   </package>

--- a/tools/java-source-utils/src/test/resources/com/microsoft/android/JavaType.xml
+++ b/tools/java-source-utils/src/test/resources/com/microsoft/android/JavaType.xml
@@ -2,192 +2,122 @@
 <api api-source="java-source-utils">
   <package jni-name="com/xamarin" name="com.xamarin">
     <class jni-signature="Lcom/xamarin/JavaEnum;" name="JavaEnum">
-      <javadoc>
-        <![CDATA[JNI sig: Lcom/xamarin/JavaEnum;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaEnum;]]></javadoc>
       <method jni-return="I" jni-signature="()I" name="switchValue" return="int">
-        <javadoc>
-          <![CDATA[summary
+        <javadoc><![CDATA[summary
 
 <p>Paragraphs of text?
 
-@return some value]]>
-        </javadoc>
+@return some value]]></javadoc>
       </method>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType;" name="JavaType">
-      <javadoc>
-        <![CDATA[JNI sig: Lcom/xamarin/JavaType;
+      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType;
 
-@param <E>]]>
-      </javadoc>
+@param <E>]]></javadoc>
       <constructor jni-signature="()V">
-        <javadoc>
-          <![CDATA[JNI sig: ()V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: ()V]]></javadoc>
       </constructor>
       <constructor jni-signature="(Ljava/lang/String;)V">
         <parameter jni-type="Ljava/lang/String;" name="value" type="java.lang.String"/>
-        <javadoc>
-          <![CDATA[JNI sig: (Ljava/lang/String;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: (Ljava/lang/String;)V]]></javadoc>
       </constructor>
       <field jni-signature="Ljava/lang/Object;" name="INSTANCE_FINAL_E">
-        <javadoc>
-          <![CDATA[JNI sig: INSTANCE_FINAL_E.Ljava/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: INSTANCE_FINAL_E.Ljava/lang/Object;]]></javadoc>
       </field>
       <field jni-signature="Ljava/lang/Object;" name="INSTANCE_FINAL_OBJECT">
-        <javadoc>
-          <![CDATA[JNI sig: INSTANCE_FINAL_OBJECT.Ljava/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: INSTANCE_FINAL_OBJECT.Ljava/lang/Object;]]></javadoc>
       </field>
       <field jni-signature="D" name="NEGATIVE_INFINITY">
-        <javadoc>
-          <![CDATA[JNI sig: NEGATIVE_INFINITY.D]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: NEGATIVE_INFINITY.D]]></javadoc>
       </field>
       <field jni-signature="D" name="NaN">
-        <javadoc>
-          <![CDATA[JNI sig: NaN.D]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: NaN.D]]></javadoc>
       </field>
       <field jni-signature="D" name="POSITIVE_INFINITY">
-        <javadoc>
-          <![CDATA[JNI sig: POSITIVE_INFINITY.D]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: POSITIVE_INFINITY.D]]></javadoc>
       </field>
       <field jni-signature="Z" name="STATIC_FINAL_BOOL_FALSE">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_BOOL_FALSE.Z]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_BOOL_FALSE.Z]]></javadoc>
       </field>
       <field jni-signature="Z" name="STATIC_FINAL_BOOL_TRUE">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_BOOL_TRUE.Z]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_BOOL_TRUE.Z]]></javadoc>
       </field>
       <field jni-signature="C" name="STATIC_FINAL_CHAR_MAX">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_CHAR_MAX.C]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_CHAR_MAX.C]]></javadoc>
       </field>
       <field jni-signature="C" name="STATIC_FINAL_CHAR_MIN">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_CHAR_MIN.C]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_CHAR_MIN.C]]></javadoc>
       </field>
       <field jni-signature="D" name="STATIC_FINAL_DOUBLE_MAX">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MAX.D]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MAX.D]]></javadoc>
       </field>
       <field jni-signature="D" name="STATIC_FINAL_DOUBLE_MIN">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MIN.D]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_DOUBLE_MIN.D]]></javadoc>
       </field>
       <field jni-signature="I" name="STATIC_FINAL_INT32">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_INT32.I]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT32.I]]></javadoc>
       </field>
       <field jni-signature="I" name="STATIC_FINAL_INT32_MAX">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_INT32_MAX.I]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT32_MAX.I]]></javadoc>
       </field>
       <field jni-signature="I" name="STATIC_FINAL_INT32_MIN">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_INT32_MIN.I]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT32_MIN.I]]></javadoc>
       </field>
       <field jni-signature="J" name="STATIC_FINAL_INT64_MAX">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_INT64_MAX.J]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT64_MAX.J]]></javadoc>
       </field>
       <field jni-signature="J" name="STATIC_FINAL_INT64_MIN">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_INT64_MIN.J]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_INT64_MIN.J]]></javadoc>
       </field>
       <field jni-signature="Ljava/lang/Object;" name="STATIC_FINAL_OBJECT">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_OBJECT.L/java/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_OBJECT.L/java/lang/Object;]]></javadoc>
       </field>
       <field jni-signature="F" name="STATIC_FINAL_SINGLE_MAX">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_SINGLE_MAX.F]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_SINGLE_MAX.F]]></javadoc>
       </field>
       <field jni-signature="F" name="STATIC_FINAL_SINGLE_MIN">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_SINGLE_MIN.F]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_SINGLE_MIN.F]]></javadoc>
       </field>
       <field jni-signature="Ljava/lang/String;" name="STATIC_FINAL_STRING">
-        <javadoc>
-          <![CDATA[JNI sig: STATIC_FINAL_STRING.Ljava/lang/String;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: STATIC_FINAL_STRING.Ljava/lang/String;]]></javadoc>
       </field>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;)V" name="action" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="java.lang.Object"/>
-        <javadoc>
-          <![CDATA[JNI sig: action.(Ljava/lang/Object;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: action.(Ljava/lang/Object;)V]]></javadoc>
       </method>
       <method jni-return="I" jni-signature="(Lcom/xamarin/JavaType;)I" name="compareTo" return="int">
         <parameter jni-type="Lcom/xamarin/JavaType;" name="value" type="com.xamarin.JavaType&lt;E&gt;"/>
-        <javadoc>
-          <![CDATA[JNI sig: compareTo.(Lcom/xamarin/JavaType;)I]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: compareTo.(Lcom/xamarin/JavaType;)I]]></javadoc>
       </method>
       <method jni-return="V" jni-signature="()V" name="finalize" return="void">
-        <javadoc>
-          <![CDATA[JNI sig: finalize.()V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: finalize.()V]]></javadoc>
       </method>
       <method jni-return="I" jni-signature="(I)I" name="finalize" return="int">
         <parameter jni-type="I" name="value" type="int"/>
-        <javadoc>
-          <![CDATA[JNI sig: finalize.(I)I]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: finalize.(I)I]]></javadoc>
       </method>
       <method jni-return="Ljava/util/List;" jni-signature="(Ljava/lang/StringBuilder;)Ljava/util/List;" name="func" return="java.util.List&lt;java.lang.String&gt;">
         <parameter jni-type="Ljava/lang/StringBuilder;" name="value" type="java.lang.StringBuilder"/>
-        <javadoc>
-          <![CDATA[JNI sig: func.(Ljava/lang/StringBuilder;)Ljava/util/List;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: func.(Ljava/lang/StringBuilder;)Ljava/util/List;]]></javadoc>
       </method>
       <method jni-return="Ljava/lang/Integer;" jni-signature="([Ljava/lang/String;)Ljava/lang/Integer;" name="func" return="java.lang.Integer">
         <parameter jni-type="[Ljava/lang/String;" name="values" type="java.lang.String[]"/>
-        <javadoc>
-          <![CDATA[JNI sig: func.([Ljava/lang/String;)Ljava/lang/Integer;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: func.([Ljava/lang/String;)Ljava/lang/Integer;]]></javadoc>
       </method>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;Ljava/lang/Object;)V" name="instanceActionWithGenerics" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="T"/>
         <parameter jni-type="Ljava/lang/Object;" name="value2" type="E"/>
-        <javadoc>
-          <![CDATA[JNI sig: instanceActionWithGenerics.(Ljava/lang/Object;java/lang/Object;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: instanceActionWithGenerics.(Ljava/lang/Object;java/lang/Object;)V]]></javadoc>
       </method>
       <field jni-signature="[Ljava/lang/Object;" name="packageInstanceEArray">
-        <javadoc>
-          <![CDATA[JNI sig: packageInstanceEArray.[Ljava/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: packageInstanceEArray.[Ljava/lang/Object;]]></javadoc>
       </field>
       <field jni-signature="Ljava/util/List;" name="protectedInstanceEList">
-        <javadoc>
-          <![CDATA[JNI sig: protectedInstanceEList.Ljava/util/List;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: protectedInstanceEList.Ljava/util/List;]]></javadoc>
       </field>
       <method jni-return="V" jni-signature="()V" name="run" return="void">
-        <javadoc>
-          <![CDATA[JNI sig: run.()V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: run.()V]]></javadoc>
       </method>
       <method jni-return="V" jni-signature="(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V" name="staticActionWithGenerics" return="void">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="T"/>
@@ -195,73 +125,49 @@
         <parameter jni-type="Ljava/util/List;" name="unboundedList" type="java.util.List&lt;?&gt;"/>
         <parameter jni-type="Ljava/util/List;" name="extendsList" type="java.util.List&lt;? extends java.lang.Number&gt;"/>
         <parameter jni-type="Ljava/util/List;" name="superList" type="java.util.List&lt;? super java.lang.Throwable&gt;"/>
-        <javadoc>
-          <![CDATA[JNI sig: staticActionWithGenerics.(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: staticActionWithGenerics.(Ljava/lang/Object;Ljava/lang/Number;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V]]></javadoc>
       </method>
       <method jni-return="I" jni-signature="(I[I)I" name="sum" return="int">
         <parameter jni-type="I" name="first" type="int"/>
         <parameter jni-type="[I" name="remaining" type="int..."/>
-        <javadoc>
-          <![CDATA[JNI sig: sum.(I[I)I]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: sum.(I[I)I]]></javadoc>
       </method>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$ASC;" name="JavaType.ASC">
-      <javadoc>
-        <![CDATA[JNI sig: Lcom/xamarin/JavaType$ASC;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$ASC;]]></javadoc>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$PSC;" name="JavaType.PSC">
-      <javadoc>
-        <![CDATA[JNI sig: Lcom/xamarin/JavaType$PSC;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$PSC;]]></javadoc>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$RNC;" name="JavaType.RNC">
-      <javadoc>
-        <![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC;]]></javadoc>
       <constructor jni-signature="()V">
-        <javadoc>
-          <![CDATA[JNI sig: ()V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: ()V]]></javadoc>
       </constructor>
       <constructor jni-signature="(Ljava/lang/Object;Ljava/lang/Object;)V">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="E"/>
         <parameter jni-type="Ljava/lang/Object;" name="value2" type="E2"/>
-        <javadoc>
-          <![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;)V]]></javadoc>
       </constructor>
       <method jni-return="Ljava/lang/Object;" jni-signature="(Ljava/lang/Object;)Ljava/lang/Object;" name="fromE" return="E2">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="E"/>
-        <javadoc>
-          <![CDATA[JNI sig: (Ljava/lang/Object;)Ljava/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: (Ljava/lang/Object;)Ljava/lang/Object;]]></javadoc>
       </method>
     </class>
     <class jni-signature="Lcom/xamarin/JavaType$RNC$RPNC;" name="JavaType.RNC.RPNC">
-      <javadoc>
-        <![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC$RPNC;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lcom/xamarin/JavaType$RNC$RPNC;]]></javadoc>
       <constructor jni-signature="()V">
-        <javadoc>
-          <![CDATA[JNI sig: ()V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: ()V]]></javadoc>
       </constructor>
       <constructor jni-signature="(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V">
         <parameter jni-type="Ljava/lang/Object;" name="value1" type="E"/>
         <parameter jni-type="Ljava/lang/Object;" name="value2" type="E2"/>
         <parameter jni-type="Ljava/lang/Object;" name="value3" type="E3"/>
-        <javadoc>
-          <![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V]]></javadoc>
       </constructor>
       <method jni-return="Ljava/lang/Object;" jni-signature="(Ljava/lang/Object;)Ljava/lang/Object;" name="fromE2" return="E3">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="E2"/>
-        <javadoc>
-          <![CDATA[JNI sig: fromE2.(Ljava/lang/Object;)Ljava/lang/Object;]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: fromE2.(Ljava/lang/Object;)Ljava/lang/Object;]]></javadoc>
       </method>
     </class>
   </package>

--- a/tools/java-source-utils/src/test/resources/com/microsoft/android/Outer.xml
+++ b/tools/java-source-utils/src/test/resources/com/microsoft/android/Outer.xml
@@ -2,103 +2,77 @@
 <api api-source="java-source-utils">
   <package jni-name="example" name="example">
     <class jni-signature="Lexample/Outer;" name="Outer">
-      <javadoc>
-        <![CDATA[Yay, Javadoc!
+      <javadoc><![CDATA[Yay, Javadoc!
 
-JNI sig: Lexample/Outer;]]>
-      </javadoc>
+JNI sig: Lexample/Outer;]]></javadoc>
       <constructor jni-signature="(Ljava/lang/Object;)V">
         <parameter jni-type="Ljava/lang/Object;" name="value" type="T"/>
-        <javadoc>
-          <![CDATA[<init>(java.lang.Object value)
+        <javadoc><![CDATA[<init>(java.lang.Object value)
 
-JNI sig: (Ljava/lang/Object;)V]]>
-        </javadoc>
+JNI sig: (Ljava/lang/Object;)V]]></javadoc>
       </constructor>
       <method jni-return="Ljava/lang/Error;" jni-signature="(Ljava/util/List;)Ljava/lang/Error;" name="isU" return="U">
         <parameter jni-type="Ljava/util/List;" name="list" type="java.util.List&lt;? super U&gt;"/>
-        <javadoc>
-          <![CDATA[isU(java.util.List<? super U> list)
+        <javadoc><![CDATA[isU(java.util.List<? super U> list)
 
 <p>This is a paragraph.  Yay?</p>
 
 JNI sig: (Ljava/util/List;)Ljava/lang/Error;
 
 @param list just some random items
-@return some value]]>
-        </javadoc>
+@return some value]]></javadoc>
       </method>
       <method jni-return="V" jni-signature="([Ljava/lang/String;)V" name="main" return="void">
         <parameter jni-type="[Ljava/lang/String;" name="args" type="java.lang.String[]"/>
-        <javadoc>
-          <![CDATA[main(java.lang.String[] args)
+        <javadoc><![CDATA[main(java.lang.String[] args)
 
-JNI sig: ([Ljava/lang/String;)V]]>
-        </javadoc>
+JNI sig: ([Ljava/lang/String;)V]]></javadoc>
       </method>
       <method jni-return="Ljava/lang/Appendable;" jni-signature="(Ljava/lang/CharSequence;[S[Ljava/lang/Appendable;)Ljava/lang/Appendable;" name="method" return="T">
         <parameter jni-type="Ljava/lang/CharSequence;" name="a" type="java.lang.CharSequence"/>
         <parameter jni-type="[S" name="b" type="short[]"/>
         <parameter jni-type="[Ljava/lang/Appendable;" name="values" type="T[]"/>
-        <javadoc>
-          <![CDATA[method(java.lang.CharSequence a, short[] b, T[] values)
+        <javadoc><![CDATA[method(java.lang.CharSequence a, short[] b, T[] values)
 
-JNI sig: (Ljava/lang/CharSequence;[S[Ljava/lang/Appendable;)Ljava/lang/Appendable;]]>
-        </javadoc>
+JNI sig: (Ljava/lang/CharSequence;[S[Ljava/lang/Appendable;)Ljava/lang/Appendable;]]></javadoc>
       </method>
     </class>
     <interface jni-signature="Lexample/Outer$Inner;" name="Outer.Inner">
-      <javadoc>
-        <![CDATA[JNI sig: Lexample/Outer$Inner;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lexample/Outer$Inner;]]></javadoc>
       <field jni-signature="J" name="COUNT">
-        <javadoc>
-          <![CDATA[JNI sig: J]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: J]]></javadoc>
       </field>
       <method jni-return="V" jni-signature="([[Ljava/lang/Readable;)V" name="m" return="void">
         <parameter jni-type="[[Ljava/lang/Readable;" name="values" type="V[][]"/>
-        <javadoc>
-          <![CDATA[m(U value)
+        <javadoc><![CDATA[m(U value)
 
 JNI sig: ([[Ljava/lang/Readable;)V
 
-@throws Throwable never, just because]]>
-        </javadoc>
+@throws Throwable never, just because]]></javadoc>
       </method>
     </interface>
     <class jni-signature="Lexample/Outer$Inner$NestedInner;" name="Outer.Inner.NestedInner">
-      <javadoc>
-        <![CDATA[JNI sig: Lexample/Outer$Inner$NestedInner;]]>
-      </javadoc>
+      <javadoc><![CDATA[JNI sig: Lexample/Outer$Inner$NestedInner;]]></javadoc>
       <field jni-signature="S" name="S">
-        <javadoc>
-          <![CDATA[JNI sig: S]]>
-        </javadoc>
+        <javadoc><![CDATA[JNI sig: S]]></javadoc>
       </field>
       <method jni-return="V" jni-signature="(Ljava/util/Map;)V" name="map" return="void">
         <parameter jni-type="Ljava/util/Map;" name="m" type="java.util.Map&lt;T, java.lang.String&gt;"/>
-        <javadoc>
-          <![CDATA[map(java.util.Map<T, String> map)
+        <javadoc><![CDATA[map(java.util.Map<T, String> map)
 
 JNI sig: map(Ljava/util/Map;)V
 
-@param map]]>
-        </javadoc>
+@param map]]></javadoc>
       </method>
     </class>
     <interface jni-signature="Lexample/Outer$MyAnnotation;" name="Outer.MyAnnotation">
-      <javadoc>
-        <![CDATA[Just an example annotation, for use later…
+      <javadoc><![CDATA[Just an example annotation, for use later…
 
-JNI sig: Lexample/Outer$MyAnnotation;]]>
-      </javadoc>
+JNI sig: Lexample/Outer$MyAnnotation;]]></javadoc>
       <method jni-return="[Ljava/lang/String;" jni-signature="()[Ljava/lang/String;" name="keys" return="java.lang.String[]">
-        <javadoc>
-          <![CDATA[JNI sig: ()[Ljava/lang/String;
+        <javadoc><![CDATA[JNI sig: ()[Ljava/lang/String;
 
-@return some random keys]]>
-        </javadoc>
+@return some random keys]]></javadoc>
       </method>
     </interface>
   </package>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/commit/df68c208ad02d09ebb9e6a87053343985dfc1e36

dotnet/android requires JDK-17, as of dotnet/android@df68c208.

Update the dotnet/java-interop build to prefer JDK-17, for consistency.

Additionally, *replace* use of `javac -source X -target X` with `javac --release X`, as this removes a build warning:

	EXEC : warning : [options] system modules path not set in conjunction with -source 11