### PR TITLE
[Java.Interop] JavaException supports param override

### DIFF
--- a/src/Java.Interop/Java.Interop/JavaObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaObject.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Java.Interop
 {
@@ -13,19 +14,23 @@ namespace Java.Interop
 
 		readonly static JniPeerMembers _members = new JniPeerMembers ("java/lang/Object", typeof (JavaObject));
 
-		public int                  JniIdentityHashCode { get; private set; }
-		public JniManagedPeerStates JniManagedPeerState { get; private set; }
+		[NonSerialized] int                     identityHashCode;
+		[NonSerialized] JniManagedPeerStates    managedPeerState;
+
+		public int                  JniIdentityHashCode => identityHashCode;
+
+		public JniManagedPeerStates JniManagedPeerState => managedPeerState;
 
 #if FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
-		JniObjectReference  reference;
+		[NonSerialized] JniObjectReference  reference;
 #endif  // FEATURE_JNIOBJECTREFERENCE_SAFEHANDLES
 #if FEATURE_JNIOBJECTREFERENCE_INTPTRS
-		IntPtr                  handle;
-		JniObjectReferenceType  handle_type;
+		[NonSerialized] IntPtr                  handle;
+		[NonSerialized] JniObjectReferenceType  handle_type;
 	#pragma warning disable 0169
 		// Used by JavaInteropGCBridge
-		IntPtr                  weak_handle;
-		int                     refs_added;
+		[NonSerialized] IntPtr                  weak_handle;
+		[NonSerialized] int                     refs_added;
 	#pragma warning restore 0169
 #endif  // FEATURE_JNIOBJECTREFERENCE_INTPTRS
 
@@ -152,12 +157,12 @@ namespace Java.Interop
 
 		void IJavaPeerable.SetJniIdentityHashCode (int value)
 		{
-			JniIdentityHashCode = value;
+			identityHashCode    = value;
 		}
 
 		void IJavaPeerable.SetJniManagedPeerState (JniManagedPeerStates value)
 		{
-			JniManagedPeerState = value;
+			managedPeerState    = value;
 		}
 
 		void IJavaPeerable.SetPeerReference (JniObjectReference reference)

--- a/src/Java.Interop/Java.Interop/JavaObject.cs
+++ b/src/Java.Interop/Java.Interop/JavaObject.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Java.Interop
 {
 	[JniTypeSignature ("java/lang/Object", GenerateJavaPeer=false)]
+	[Serializable]
 	unsafe public class JavaObject : IJavaPeerable
 	{
 		internal const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -97,8 +97,13 @@ namespace Java.Interop
 
 				var newRef  = peer.PeerReference;
 				if (newRef.IsValid) {
-					// Activation! See ManagedPeer.RunConstructor
-					peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Activatable);
+					JniObjectReference.Dispose (ref reference, options);
+
+					// Activation? See ManagedPeer.Construct, CreatePeer
+					// Instance was already added, don't add again
+					if (peer.JniManagedPeerState.HasFlag (JniManagedPeerStates.Activatable)) {
+						return;
+					}
 					JniObjectReference.Dispose (ref reference, options);
 					newRef   = newRef.NewGlobalRef ();
 				} else if (options == JniObjectReferenceOptions.None) {

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ static Java.Interop.JniEnvironment.BeginMarshalMethod(nint jnienv, out Java.Inte
 static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransition transition) -> void
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void
-Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReferenceOptions throwableOverride) -> void
-Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride) -> void
+Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReference throwableOverride) -> void
+Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride = default(Java.Interop.JniObjectReference)) -> void
 Java.Interop.JniTypeSignatureAttribute.InvokerType.get -> System.Type?
 Java.Interop.JniTypeSignatureAttribute.InvokerType.set -> void

--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -3,5 +3,7 @@ static Java.Interop.JniEnvironment.BeginMarshalMethod(nint jnienv, out Java.Inte
 static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransition transition) -> void
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void
+Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReferenceOptions throwableOverride) -> void
+Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride) -> void
 Java.Interop.JniTypeSignatureAttribute.InvokerType.get -> System.Type?
 Java.Interop.JniTypeSignatureAttribute.InvokerType.set -> void


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9640
Context: 25de1f38bb6b3ef2d4c98d2d95923a4bd50d2ea0

dotnet/android#9640 completes "unification" with dotnet/java-interop, updating `Java.Lang.Object` to inherit `Java.Interop.JavaObject`, just like `src/Java.Base`.

The biggest impediment with this unification step is that the semantics for referring to a Java instance are quite different:

  * .NET for Android née Xamarin.Android née Mono for Android uses an `(IntPtr, JniHandleOwnership)` pair to specify the JNI object reference pointer value and what should be done with it. The *type* of the JNI object reference is *inferred* by the `JniHandleOwnership` value, e.g. `JniHandleOwnership.TransferLocalRef` means that the `IntPtr` value is a JNI local reference.

  * dotnet/java-interop uses a `(ref JniObjectReference, JniObjectReferenceOptions)` pair to specify the JNI object reference and what can be done with it. The `JniObjectReference` value contains the type, but -- due to "pointer trickery"; see 25de1f38 -- it might be *so* invalid that it cannot be touched at all, and `JniObjectReferenceOptions` will let us know.

Which brings us to the conundrum: how do we implement the `Java.Lang.Throwable(IntPtr, JniHandleOwnership)` constructor?

	namespace Java.Lang {
	    public class Throwable {
	        public Throwable(IntPtr handle, JniHandleOwnership transfer);
	    }
	}

The "obvious and wrong" solution would be to use `ref` with a temporary…

	public Throwable(IntPtr handle, JniHandleOwnership transfer)
	    : base (ref new JniObjectReference(handle), …)
	{
	}

…but that won't compile.

Next, we want to be able to provide `message` and `innerException` parameters to `System.Exception`, but the
`JavaException(ref JniObjectReference, JniObjectReferenceOptions)` constructor requires a valid JNI Object Reference to do that.

If `Java.Lang.Throwable` tries to "work around" this by using the `JavaException(string, Exception)` constructor:

	public Throwable(IntPtr handle, JniHandleOwnership transfer)
	    : base (_GetMessage (handle), _GetInnerException (handle))
	{
	    …
	}

then the `JavaException(string, Exception)` constructor will try to invoke the `E(String)` constructor on the Java side, which:

 1. Is semantically wrong, because we may already have a Java instance in `handle`, so why are we creating a new instance? But-

 2. This fails for constructor subclasses which don't provide a `E(String)` constructor!  Specifically, the [`JnienvTest.ActivatedDirectThrowableSubclassesShouldBeRegistered`][0] unit test starts crashing for "bizarre" reasons.

Fix these issues by adding the new exception:

	namespace Java.Interop {
	    partial class JavaException {
		protected JavaException (
	                ref JniObjectReference reference,
	                JniObjectReferenceOptions transfer,
	                JniObjectReference throwableOverride);
	    }
	}

The new `throwableOverride` parameter is used to obtain the `message` and `innerException` values to provide to the
`System.Exception(string, Exception)` constructor, allowing `reference` to be a "do not touch" value.

Additionally, add a `protected SetJavaStackTrace()` method which is used to set the `JavaException.JavaStackTrace` property based on a `JniObjectReference` value.

[0]: https://github.com/dotnet/android/blob/main/tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs#L285-L305