### PR TITLE
[ci] Add dev/* branches to CI trigger

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -5,6 +5,7 @@ trigger:
   - release/*
   - d17-*
   - dependabot/*
+  - dev/*
 
 pr:
   branches:


### PR DESCRIPTION
Adds dev branches to the CI trigger to kick off builds on these branches
automatically now that PR build restrictions are in place for GitHub
repos.