### PR TITLE
Does main build?

### DIFF
--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -26,6 +26,10 @@
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
+    <ProjectReference
+        Include="..\..\tools\jcw-gen\jcw-gen.csproj"
+        ReferenceOutputAssembly="false"
+    />
   </ItemGroup>
   
   <ItemGroup>

--- a/tools/generator/SourceWriters/BoundClass.cs
+++ b/tools/generator/SourceWriters/BoundClass.cs
@@ -83,7 +83,7 @@ namespace generator.SourceWriters
 				NestedTypes.Add (ic);
 
 			// Sibling classes
-			if (!klass.AssemblyQualifiedName.Contains ('/')) {
+			if (!klass.AssemblyQualifiedName.Contains ('+')) {
 				foreach (InterfaceExtensionInfo nestedIface in klass.GetNestedInterfaceTypes ())
 					if (nestedIface.Type.Methods.Any (m => m.CanHaveStringOverload) || nestedIface.Type.Methods.Any (m => m.Asyncify))
 						sibling_types.Add (new InterfaceExtensionsClass (nestedIface.Type, nestedIface.DeclaringType, opt));

--- a/tools/generator/SourceWriters/BoundInterface.cs
+++ b/tools/generator/SourceWriters/BoundInterface.cs
@@ -78,7 +78,7 @@ namespace generator.SourceWriters
 			if (iface.IsConstSugar (opt))
 				return;
 
-			if (!iface.AssemblyQualifiedName.Contains ('/')) {
+			if (!iface.AssemblyQualifiedName.Contains ('+')) {
 				if (iface.Methods.Any (m => m.CanHaveStringOverload) || iface.Methods.Any (m => m.Asyncify))
 					post_sibling_types.Add (new InterfaceExtensionsClass (iface, null, opt));
 			}


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=10949922&view=logs&j=fc903661-9840-55b3-f380-f59f595bd021&t=96c38280-19e2-5308-b6a5-3c71c0cffc81
Context: https://github.com/dotnet/java-interop/pull/1302

PR #1302 is failing on Windows for a non-obvious reason:

    Java.Interop.Export-Tests -> D:\a\1\s\bin\TestRelease-net8.0\Java.Interop.Export-Tests.dll
      Possible reasons for this include:
        * You misspelled a built-in dotnet command.
        * You intended to execute a .NET program, but dotnet-D:\a\1\s\bin\Release-net8.0\/jcw-gen.dll does not exist. Could not execute because the specified command or file was not found. * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH. ##[error]tests\Java.Interop.Export-Tests\Java.Interop.Export-Tests.targets(20,5): Error MSB3073: The command "dotnet "D:\a\1\s\bin\Release-net8.0\/jcw-gen.dll" "D:\a\1\s\bin\TestRelease-net8.0\Java.Interop.Export-Tests.dll" --codegen-target JavaInterop1 -o "obj\\Release-net8.0\/java" -L "D:\a\1\s\src\Java.Base\bin\Release\ref\." -L "D:\a\1\s\bin\Release-net8.0\ref\." -L "D:\a\1\s\bin\TestRelease-net8.0\ref\." -L "C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.7\ref\net8.0\." -L "C:\Users\VssAdministrator\.nuget\packages\microsoft.testplatform.testhost\17.5.0-preview-20221003-04\lib\netcoreapp3.1\." -L "C:\Users\VssAdministrator\.nuget\packages\microsoft.codecoverage\17.5.0-preview-20221003-04\lib\netcoreapp3.1\." -L "C:\Users\VssAdministrator\.nuget\packages\mono.linq.expressions\2.0.0\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\mono.options\6.12.0.148\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\newtonsoft.json\13.0.1\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\nuget.frameworks\5.11.0\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\nunit\3.13.2\lib\netstandard2.0\." -L "D:\a\1\s\external\xamarin-android-tools\bin\Release\net6.0\ref\."" exited with code 1. D:\a\1\s\tests\Java.Interop.Export-Tests\Java.Interop.Export-Tests.targets(20,5): error MSB3073: The command "dotnet "D:\a\1\s\bin\Release-net8.0\/jcw-gen.dll" "D:\a\1\s\bin\TestRelease-net8.0\Java.Interop.Export-Tests.dll" --codegen-target JavaInterop1 -o "obj\\Release-net8.0\/java" -L "D:\a\1\s\src\Java.Base\bin\Release\ref\." -L "D:\a\1\s\bin\Release-net8.0\ref\." -L "D:\a\1\s\bin\TestRelease-net8.0\ref\." -L "C:\hostedtoolcache\windows\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.7\ref\net8.0\." -L "C:\Users\VssAdministrator\.nuget\packages\microsoft.testplatform.testhost\17.5.0-preview-20221003-04\lib\netcoreapp3.1\." -L "C:\Users\VssAdministrator\.nuget\packages\microsoft.codecoverage\17.5.0-preview-20221003-04\lib\netcoreapp3.1\." -L "C:\Users\VssAdministrator\.nuget\packages\mono.linq.expressions\2.0.0\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\mono.options\6.12.0.148\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\newtonsoft.json\13.0.1\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\nuget.frameworks\5.11.0\lib\netstandard2.0\." -L "C:\Users\VssAdministrator\.nuget\packages\nunit\3.13.2\lib\netstandard2.0\." -L "D:\a\1\s\external\xamarin-android-tools\bin\Release\net6.0\ref\."" exited with code 1. [D:\a\1\s\tests\Java.Interop.Export-Tests\Java.Interop.Export-Tests.csproj]

Given that *later* in the build, we see:

      jcw-gen -> D:\a\1\s\bin\Release-net8.0\jcw-gen.dll

it looks like we have a build ordering issue, and
`tests/Java.Interop.Export-Tests` is being run *before* `jcw-gen`?