### PR TITLE
[jcw-gen] Use `+` for nested types, not `/`

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs
@@ -269,7 +269,7 @@ public class CecilImporter
 	static CallableWrapperMethod CreateMethod (string name, CallableWrapperType declaringType, string? signature, string? connector, string? managedParameters, string? outerType, string? superCall)
 	{
 		signature = signature ?? throw new ArgumentNullException ("`connector` cannot be null.", nameof (connector));
-		var method_name = "n_" + name + ":" + signature + ":" + connector;
+		var method_name = "n_" + name + ":" + signature + ":" + connector?.Replace ('/', '+');
 
 		var method = new CallableWrapperMethod (declaringType, name, method_name, signature);
 

--- a/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
+++ b/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs
@@ -150,7 +150,7 @@ namespace Java.Interop.Tools.TypeNameMappings
 			for (int i = 0; i < parts.Length; ++i) {
 				parts [i] = ToPascalCase (parts [i], 1);
 			}
-			return string.Join ("/", parts);
+			return string.Join ("+", parts);
 		}
 
 		static string ToPascalCase (string value, int minLength)

--- a/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
+++ b/tests/Java.Interop.Export-Tests/Java.Interop.Export-Tests.csproj
@@ -26,6 +26,10 @@
     <ProjectReference Include="..\..\src\Java.Interop.Export\Java.Interop.Export.csproj" />
     <ProjectReference Include="..\..\src\Java.Runtime.Environment\Java.Runtime.Environment.csproj" />
     <ProjectReference Include="..\TestJVM\TestJVM.csproj" />
+    <ProjectReference
+        Include="..\..\tools\jcw-gen\jcw-gen.csproj"
+        ReferenceOutputAssembly="false"
+    />
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/JavaCallableWrapperGeneratorTests.cs
@@ -104,6 +104,55 @@ public class Name
 			Assert.AreEqual (expected, actual);
 		}
 
+		[Test]
+		public void GenerateTypeMentioningNestedInvoker ()
+		{
+			var actual      = Generate (typeof (ApplicationName.ActivityLifecycleCallbacks));
+			var expected    = """
+package application;
+
+
+public class Name_ActivityLifecycleCallbacks
+	extends java.lang.Object
+	implements
+		mono.android.IGCUserPeer,
+		java.lang.Object
+{
+/** @hide */
+	public static final String __md_methods;
+	static {
+		__md_methods = 
+			"n_onActivityCreated:(Landroid/app/Activity;Landroid/os/Bundle;)V:GetOnActivityCreated_Landroid_app_Activity_Landroid_os_Bundle_Handler:Android.App.Application+IActivityLifecycleCallbacksInvoker, Mono.Android\n" +
+			"";
+		mono.android.Runtime.register ("Xamarin.Android.ToolsTests.ApplicationName+ActivityLifecycleCallbacks, Java.Interop.Tools.JavaCallableWrappers-Tests", Name_ActivityLifecycleCallbacks.class, __md_methods);
+	}
+
+	public void onActivityCreated (android.app.Activity p0, android.os.Bundle p1)
+	{
+		n_onActivityCreated (p0, p1);
+	}
+
+	private native void n_onActivityCreated (android.app.Activity p0, android.os.Bundle p1);
+
+	private java.util.ArrayList refList;
+	public void monodroidAddReference (java.lang.Object obj)
+	{
+		if (refList == null)
+			refList = new java.util.ArrayList ();
+		refList.add (obj);
+	}
+
+	public void monodroidClearReferences ()
+	{
+		if (refList != null)
+			refList.clear ();
+	}
+}
+
+""";
+			Assert.AreEqual (expected, actual);
+		}
+
 		static string Generate (Type type, string applicationJavaClass = null, string monoRuntimeInit = null, JavaPeerStyle style = JavaPeerStyle.XAJavaInterop1)
 		{
 			var reader_options = new CallableWrapperReaderOptions {

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/SupportDeclarations.cs
@@ -22,6 +22,26 @@ namespace Android.App {
 		protected virtual void OnCreate ()
 		{
 		}
+
+		[Register ("android/app/Application$ActivityLifecycleCallbacks", DoNotGenerateAcw = true)]
+		public partial interface IActivityLifecycleCallbacks {
+			[Register (
+				name: "onActivityCreated",
+				signature: "(Landroid/app/Activity;Landroid/os/Bundle;)V",
+				connector: "GetOnActivityCreated_Landroid_app_Activity_Landroid_os_Bundle_Handler:Android.App.Application/IActivityLifecycleCallbacksInvoker, Mono.Android")]
+			void OnActivityCreated (Android.App.Activity activity, global::Android.OS.Bundle savedInstanceState);
+		}
+
+		internal class IActivityLifecycleCallbacksInvoker : Java.Lang.Object, IActivityLifecycleCallbacks {
+			static Delegate GetOnActivityCreated_Landroid_app_Activity_Landroid_os_Bundle_Handler ()
+			{
+				return null;
+			}
+
+			public void OnActivityCreated (Android.App.Activity activity, global::Android.OS.Bundle savedInstanceState)
+			{
+			}
+		}
 	}
 
 	[Register ("android/app/Activity", DoNotGenerateAcw = true)]
@@ -40,6 +60,14 @@ namespace Android.App {
 		public virtual void OnCreate (Java.Lang.Object arguments)
 		{
 		}
+	}
+}
+
+namespace Android.OS {
+
+	[Register ("android/os/Bundle", DoNotGenerateAcw = true)]
+	class Bundle : Java.Lang.Object
+	{
 	}
 }
 
@@ -72,6 +100,7 @@ namespace Xamarin.Android.ToolsTests {
 			typeof (AbstractClass),
 			typeof (ActivityName),
 			typeof (ApplicationName),
+			typeof (ApplicationName.ActivityLifecycleCallbacks),
 			typeof (DefaultName),
 			typeof (DefaultName.A),
 			typeof (DefaultName.A.B),
@@ -139,6 +168,12 @@ namespace Xamarin.Android.ToolsTests {
 	[Application (Name = "application.Name")]
 	class ApplicationName : Application
 	{
+		public class ActivityLifecycleCallbacks : Java.Lang.Object, Application.IActivityLifecycleCallbacks
+		{
+			public void OnActivityCreated (Activity activity, global::Android.OS.Bundle savedInstanceState)
+			{
+			}
+		}
 	}
 
 	class IndirectApplication : ApplicationName

--- a/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
+++ b/tests/Java.Interop.Tools.JavaCallableWrappers-Tests/Java.Interop.Tools.JavaCallableWrappers/TypeNameMapGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Android.ToolsTests
 			v.WriteJavaToManaged (o);
 			var a = ToArray (o);
 			Save (a, "__j2m");
-			var length = 190;
+			var length = 193;
 			var offset = 76;
 			var e =
 				"version=1\u0000" +
@@ -59,6 +59,7 @@ namespace Xamarin.Android.ToolsTests
 				"value-offset=" + offset + "\u0000" +
 				GetJ2MEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
 				GetJ2MEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
+				GetJ2MEntryLine (typeof (ApplicationName.ActivityLifecycleCallbacks),   "application/Name_ActivityLifecycleCallbacks",                                              offset, length) +
 				GetJ2MEntryLine (typeof (DefaultName),                              "crc64197ae30a36756915/DefaultName",                                                            offset, length) +
 				GetJ2MEntryLine (typeof (DefaultName.A),                            "crc64197ae30a36756915/DefaultName_A",                                                          offset, length) +
 				GetJ2MEntryLine (typeof (DefaultName.A.B),                          "crc64197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
@@ -128,8 +129,8 @@ namespace Xamarin.Android.ToolsTests
 			v.WriteManagedToJava (o);
 			var a = ToArray (o);
 			Save (a, "__m2j");
-			var length = 190;
-			var offset = 114;
+			var length = 193;
+			var offset = 117;
 			var e =
 				"version=1\u0000" +
 				$"entry-count={types.Count}\u0000" +
@@ -138,6 +139,7 @@ namespace Xamarin.Android.ToolsTests
 				GetM2JEntryLine (typeof (AbstractClass),                            "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (AbstractClassInvoker),                     "my/AbstractClass",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (ActivityName),                             "activity/Name",                                                                                offset, length) +
+				GetM2JEntryLine (typeof (ApplicationName.ActivityLifecycleCallbacks),   "application/Name_ActivityLifecycleCallbacks",                                              offset, length) +
 				GetM2JEntryLine (typeof (ApplicationName),                          "application/Name",                                                                             offset, length) +
 				GetM2JEntryLine (typeof (DefaultName.A.B),                          "crc64197ae30a36756915/DefaultName_A_B",                                                        offset, length) +
 				GetM2JEntryLine (typeof (DefaultName.A),                            "crc64197ae30a36756915/DefaultName_A",                                                          offset, length) +

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/ClassGen.cs
@@ -181,7 +181,7 @@ namespace MonoDroid.Generation
 					int ls = reg.Key.LastIndexOf ('/');
 					string package = ls >= 0 ? reg.Key.Substring (0, ls) : "";
 
-					if (JavaNativeTypeManager.ToCliType (reg.Key) == reg.Value)
+					if (JavaNativeTypeManager.ToCliType (reg.Key) == reg.Value.Replace ('/', '+'))
 						continue;
 					if (!mapping.TryGetValue (package, out var v))
 						mapping.Add (package, v = new List<KeyValuePair<string, string>> ());


### PR DESCRIPTION
TODO: full explanation.

dotnet/java-interop#1302 and dotnet/android#9750 has turned into a bit of a boondoggle.  Maybe the better approach is to just update `jcw-gen` to use `+` instead of `/` for nested types, instead of *both* `jcw-gen` *and* `generator`, because the `generator` changes just require changes *everywhere*.

Will this smaller fix work?