### PR TITLE
[Java.Interop] GetSimpleReferences():fallback for GetTypeSignatures()

### DIFF
--- a/src/Java.Interop/Java.Interop/JavaArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaArray.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 
 namespace Java.Interop
 {
+	[JniTypeSignature ("java/lang/Object", ArrayRank=1, GenerateJavaPeer=false)]
 	public abstract class JavaArray<T> : JavaObject, IList, IList<T>
 	{
 		internal delegate TArray ArrayCreator<TArray> (ref JniObjectReference reference, JniObjectReferenceOptions transfer)
@@ -362,6 +363,7 @@ namespace Java.Interop
 		}
 	}
 	
+	[JniTypeSignature ("java/lang/Object", ArrayRank=1, GenerateJavaPeer=false)]
 	public abstract class JavaPrimitiveArray<
 			[DynamicallyAccessedMembers (Constructors)]
 			T

--- a/src/Java.Interop/Java.Interop/JavaObjectArray.cs
+++ b/src/Java.Interop/Java.Interop/JavaObjectArray.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 namespace Java.Interop
 {
+	[JniTypeSignature ("java/lang/Object", ArrayRank=1, GenerateJavaPeer=false)]
 	public class JavaObjectArray<
 			[DynamicallyAccessedMembers (Constructors)]
 			T

--- a/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniTypeManager.cs
@@ -169,17 +169,6 @@ namespace Java.Interop {
 						return new JniTypeSignature (genericSimpleRef, rank, false);
 				}
 
-				var name = type.GetCustomAttribute<JniTypeSignatureAttribute> (inherit: false);
-				if (name != null) {
-#if NET
-					var altRef = GetReplacementType (name.SimpleReference);
-					if (altRef != null) {
-						return new JniTypeSignature (altRef, name.ArrayRank + rank, name.IsKeyword);
-					}
-#endif  // NET
-					return new JniTypeSignature (name.SimpleReference, name.ArrayRank + rank, name.IsKeyword);
-				}
-
 				var simpleRef = GetSimpleReference (type);
 				if (simpleRef != null)
 					return new JniTypeSignature (simpleRef, rank, false);
@@ -218,15 +207,6 @@ namespace Java.Interop {
 							continue;
 						yield return new JniTypeSignature (genericSimpleRef, rank, false);
 					}
-				}
-
-				var name = type.GetCustomAttribute<JniTypeSignatureAttribute> (inherit: false);
-				if (name != null) {
-					var altRef = GetReplacementType (name.SimpleReference);
-					if (altRef != null) {
-						yield return new JniTypeSignature (altRef, name.ArrayRank + rank, name.IsKeyword);
-					}
-					yield return new JniTypeSignature (name.SimpleReference, name.ArrayRank + rank, name.IsKeyword);
 				}
 
 				foreach (var simpleRef in GetSimpleReferences (type)) {
@@ -268,7 +248,18 @@ namespace Java.Interop {
 					throw new ArgumentNullException (nameof (type));
 				if (type.IsArray)
 					throw new ArgumentException ("Array type '" + type.FullName + "' is not supported.", nameof (type));
-				return EmptyStringArray;
+
+				var name = type.GetCustomAttribute<JniTypeSignatureAttribute> (inherit: false);
+				if (name != null) {
+					var altRef = GetReplacementType (name.SimpleReference);
+					if (altRef != null) {
+						yield return altRef;
+					} else {
+						yield return name.SimpleReference;
+					}
+				}
+
+				yield break;
 			}
 
 			static  readonly    string[]    EmptyStringArray    = Array.Empty<string> ();

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
@@ -79,6 +79,9 @@ namespace Java.InteropTests
 
 #if !__ANDROID__
 			// Re-enable once typemap files contain `JavaObject` subclasses, not just Java.Lang.Object subclasses
+			//
+			// Note: dotnet/android@5c23bcda updates Java.Lang.Object to inherit JavaObject; this is not enough,
+			// as `<GenerateJavaStubs/>` only processes assemblies if they reference Mono.Android.dll.
 			AssertGetJniTypeInfoForType (typeof (GenericHolder<int>),       GenericHolder<int>.JniTypeName,    false,   0);
 #endif  // !__ANDROID__
 		}
@@ -86,8 +89,14 @@ namespace Java.InteropTests
 		static void AssertGetJniTypeInfoForType (Type type, string jniType, bool isKeyword, int arrayRank)
 		{
 			var info = JniRuntime.CurrentRuntime.TypeManager.GetTypeSignature (type);
-			Assert.AreEqual (jniType,   info.Name);
-			Assert.AreEqual (arrayRank, info.ArrayRank);
+
+			// `GetTypeSignature() and `GetTypeSignatures()` should be "in sync"; verify that!
+			var info2   = JniRuntime.CurrentRuntime.TypeManager.GetTypeSignatures (type).FirstOrDefault ();
+
+			Assert.AreEqual (jniType,   info.Name,          $"info.Name for `{type}`");
+			Assert.AreEqual (jniType,   info2.Name,         $"info.Name for `{type}`");
+			Assert.AreEqual (arrayRank, info.ArrayRank,     $"info.ArrayRank for `{type}`");
+			Assert.AreEqual (arrayRank, info2.ArrayRank,    $"info.ArrayRank for `{type}`");
 		}
 
 		[Test]


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9768

dotnet/android#9768 attempts to add types from `Java.Interop.dll` to the .NET for Android typemaps, in order to fix Debug warnings like:

	I monodroid-assembly: typemap: unable to find mapping to a Java type from managed type 'Java.Interop.ManagedPeer, Java.Interop'

Unfortunately, this causes the assertion:

	AssertGetJniTypeInfoForType (typeof (JavaArray<JavaObject>),    "[Ljava/lang/Object;",  false,  1);

within `Java.InteropTests.JniTypeManagerTests.GetTypeSignature_Type()` to fail:

	Expected string length 19 but was 33. Strings differ at index 0.
	Expected: "[Ljava/lang/Object;"
	But was:  "crc64d5d92128469ae06d/JavaArray_1"
	-----------^

The immediate cause of the failure is that
`JniRuntime.JniTypeManager.GetTypeSignature()` called `JniRuntime.JniTypeManager.GetSimpleReference()` *before* it tried to see if the type was `JavaArray<T>`.  As `Java.Interop.dll` was now being processed for typemap purposes, and because `JavaArray<T>` did not have a `[JniTypeSignatureAttribute]`, the typemap got the default behavior of `crc64[hash…]`.

The broader cause is that `GetSimpleReference()` should be the *fallback* implementation, used after all other attempts to get a JNI name have failed.

Update `GetTypeSignature()` and `GetTypeSignatures()` so that `GetSimpleReference()` and/or `GetSimpleReferences()` are in fact treated as fallbacks.

Additionally, update `AssertGetJniTypeInfoForType()` to assert that the value returned by `GetTypeSignature()` is the same as the value return3ed by` GetTypeSignatures().First()`.  This was *commented* as being the case, but we should *verify* that as well.

Finally, update `AssertGetJniTypeInfoForType()` so that when the assertion fails, the source `type` value is provided.