### PR TITLE
[tests] fix `NU1510` warning as error

### DIFF
--- a/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
+++ b/tests/Java.Interop.Dynamic-Tests/Java.Interop.Dynamic-Tests.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit.ConsoleRunner" />


### PR DESCRIPTION
Context: https://github.com/NuGet/NuGet.Client/pull/6239

.NET 10 Preview 1 enables `$(RestoreEnablePackagePruning)=true` by default.

This produces multiple warnings as errors in dotnet/android:

    external\Java.Interop\tests\Java.Interop.Dynamic-Tests\Java.Interop.Dynamic-Tests.csproj :
    error NU1510: Warning As Error: PackageReference Microsoft.CSharp will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.

The `Microsoft.CSharp` package does seem like it can just be removed.