### PR TITLE
[generator] Add support for emitting `[UnsupportedOSPlatform]`.

### DIFF
--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -1407,6 +1407,36 @@ namespace generatortests
 		}
 
 		[Test]
+		public void UnsupportedOSPlatform ()
+		{
+			var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
+			klass.ApiRemovedSince = 30;
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			StringAssert.Contains ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android30.0\")]", builder.ToString (), "Should contain UnsupportedOSPlatform!");
+		}
+
+		[Test]
+		public void UnsupportedOSPlatformConstFields ()
+		{
+			var klass = new TestClass ("java.lang.Object", "com.mypackage.foo");
+			var field = new TestField ("java.lang.String", "bar").SetConstant ("MY_VALUE");
+
+			field.ApiRemovedSince = 30;
+
+			klass.Fields.Add (field);
+
+			generator.Context.ContextTypes.Push (klass);
+			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
+			generator.Context.ContextTypes.Pop ();
+
+			StringAssert.Contains ("[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android30.0\")]", builder.ToString (), "Should contain UnsupportedOSPlatform!");
+		}
+
+		[Test]
 		public void StringPropertyOverride ([Values ("true", "false")] string final)
 		{
 			var xml = @$"<api>

--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -52,6 +52,15 @@ namespace generatortests
 		}
 
 		[Test]
+		public void CreateClass_CorrectApiRemoved ()
+		{
+			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='myclass' removed-since='7' /></package>");
+			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
+
+			Assert.AreEqual (7, klass.ApiRemovedSince);
+		}
+
+		[Test]
 		public void CreateCtor_EnsureValidName ()
 		{
 			var xml = XDocument.Parse ("<package name=\"com.example.test\" jni-name=\"com/example/test\"><class name=\"test\"><constructor name=\"$3\" /></class></package>");

--- a/tools/generator/ApiVersionsSupport.cs
+++ b/tools/generator/ApiVersionsSupport.cs
@@ -18,6 +18,7 @@ namespace MonoDroid.Generation
 		public interface IApiAvailability
 		{
 			int ApiAvailableSince { get; set; }
+			int ApiRemovedSince { get; set; }
 		}
 
 		static IEnumerable<GenBase> FlattenGens (IEnumerable<GenBase> gens)

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -159,6 +159,7 @@ namespace MonoDroid.Generation
 			var ctor = new Ctor (declaringType) {
 				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				ApiAvailableSince = declaringType.ApiAvailableSince,
+				ApiRemovedSince = declaringType.ApiRemovedSince,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
 				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
@@ -211,6 +212,7 @@ namespace MonoDroid.Generation
 			var field = new Field {
 				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				ApiAvailableSince = declaringType.ApiAvailableSince,
+				ApiRemovedSince = declaringType.ApiRemovedSince,
 				DeprecatedComment = elem.XGetAttribute ("deprecated"),
 				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
 				IsAcw = true,
@@ -369,6 +371,7 @@ namespace MonoDroid.Generation
 			var method = new Method (declaringType) {
 				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
 				ApiAvailableSince = declaringType.ApiAvailableSince,
+				ApiRemovedSince = declaringType.ApiRemovedSince,
 				ArgsType = elem.Attribute ("argsType")?.Value,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
@@ -515,9 +518,12 @@ namespace MonoDroid.Generation
 		// Elements need to be passed in the above order. (package, class, member)
 		static void FillApiSince (ApiVersionsSupport.IApiAvailability model, params XElement[] elems)
 		{
-			foreach (var elem in elems)
+			foreach (var elem in elems) {
 				if (int.TryParse (elem.XGetAttribute ("api-since"), out var result))
 					model.ApiAvailableSince = result;
+				if (int.TryParse (elem.XGetAttribute ("removed-since"), out var removed))
+					model.ApiRemovedSince = removed;
+			}
 		}
 
 		static bool IsObfuscatedName (int threshold, string name)

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -9,6 +9,7 @@ namespace MonoDroid.Generation
 		public string AnnotatedVisibility { get; set; }
 		public string Annotation { get; set; }
 		public int ApiAvailableSince { get; set; }
+		public int ApiRemovedSince { get; set; }
 		public string DeprecatedComment { get; set; }
 		public int? DeprecatedSince { get; set; }
 		public bool IsAcw { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -188,6 +188,8 @@ namespace MonoDroid.Generation
 
 		public int ApiAvailableSince { get; set; }
 
+		public int ApiRemovedSince { get; set; }
+
 		public virtual ClassGen BaseGen => null;
 
 		public GenBase BaseSymbol =>

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -16,6 +16,7 @@ namespace MonoDroid.Generation
 		public string AnnotatedVisibility { get; set; }
 		public string Annotation { get; internal set; }
 		public int ApiAvailableSince { get; set; }
+		public int ApiRemovedSince { get; set; }
 		public string AssemblyName { get; set; }
 		public GenBase DeclaringType { get; }
 		public string Deprecated { get; set; }

--- a/tools/generator/SourceWriters/Attributes/UnsupportedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/UnsupportedOSPlatformAttr.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.SourceWriter;
+
+namespace generator.SourceWriters
+{
+	public class UnsupportedOSPlatformAttr : AttributeWriter
+	{
+		public int Version { get; }
+
+		public UnsupportedOSPlatformAttr (int version) => Version = version;
+
+		public override void WriteAttribute (CodeWriter writer)
+		{
+			writer.WriteLine ($"[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android{Version}.0\")]");
+		}
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/java-interop/issues/1309

Sometimes, Android *removes* APIs.  For example, API-23 *removed* the `android.Manifest.permission.CLEAR_APP_USER_DATA` field.

We still list this field, though: [`Android.Manifest.Permission.ClearAppUserData` field](https://learn.microsoft.com/en-us/dotnet/api/android.manifest.permission.clearappuserdata?view=net-android-34.0)

We modified `api-merge` to add `removed-since` in https://github.com/dotnet/android/pull/8897.

Here is the excerpt from https://github.com/dotnet/android/blob/main/src/Mono.Android/Profiles/api-Baklava.xml:

```xml
<field deprecated="not deprecated" final="true" name="CLEAR_APP_USER_DATA" jni-signature="Ljava/lang/String;" static="true" transient="false" type="java.lang.String" type-generic-aware="java.lang.String" value="&quot;android.permission.CLEAR_APP_USER_DATA&quot;" visibility="public" volatile="false" removed-since="23"></field>
```

Modify `generator` to consume this information and emit `UnsupportedOSPlatformAttribute ("androidXX0")]` as needed for API that has been removed from `Mono.Android`.

Tested in `dotnet/android` with https://github.com/dotnet/android/pull/9791.