### PR TITLE
[Java.Interop] CreatePeer() must satisfy targetType

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -348,7 +348,7 @@ namespace Java.Interop
 			IJavaPeerable? CreatePeerInstance (
 					ref JniObjectReference klass,
 					[DynamicallyAccessedMembers (Constructors)]
-					Type fallbackType,
+					Type targetType,
 					ref JniObjectReference reference,
 					JniObjectReferenceOptions transfer)
 			{
@@ -362,7 +362,7 @@ namespace Java.Interop
 
 					type    = Runtime.TypeManager.GetType (sig);
 
-					if (type != null) {
+					if (type != null && targetType.IsAssignableFrom (type)) {
 						var peer = TryCreatePeerInstance (ref reference, transfer, type);
 
 						if (peer != null) {
@@ -381,7 +381,7 @@ namespace Java.Interop
 				}
 				JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
 
-				return TryCreatePeerInstance (ref reference, transfer, fallbackType);
+				return TryCreatePeerInstance (ref reference, transfer, targetType);
 			}
 
 			IJavaPeerable? TryCreatePeerInstance (

--- a/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
+++ b/tests/Java.Interop-Tests/Java.Interop-Tests.csproj
@@ -36,6 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\AnotherJavaInterfaceImpl.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CrossReferenceBridge.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallNonvirtualBase.java" />
     <JavaInteropTestJar Include="$(MSBuildThisFileDirectory)java\net\dot\jni\test\CallNonvirtualDerived.java" />

--- a/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaVMFixture.cs
@@ -37,6 +37,7 @@ namespace Java.InteropTests {
 			[GenericHolder<int>.JniTypeName]    = typeof (GenericHolder<>),
 			[RenameClassBase.JniTypeName]       = typeof (RenameClassBase),
 			[RenameClassDerived.JniTypeName]    = typeof (RenameClassDerived),
+			[AnotherJavaInterfaceImpl.JniTypeName]          = typeof (AnotherJavaInterfaceImpl),
 			[CallVirtualFromConstructorBase.JniTypeName]    = typeof (CallVirtualFromConstructorBase),
 			[CallVirtualFromConstructorDerived.JniTypeName] = typeof (CallVirtualFromConstructorDerived),
 			[CrossReferenceBridge.JniTypeName]              = typeof (CrossReferenceBridge),

--- a/tests/Java.Interop-Tests/java/net/dot/jni/test/AnotherJavaInterfaceImpl.java
+++ b/tests/Java.Interop-Tests/java/net/dot/jni/test/AnotherJavaInterfaceImpl.java
@@ -1,0 +1,13 @@
+package net.dot.jni.test;
+
+public class AnotherJavaInterfaceImpl
+	implements JavaInterface, Cloneable
+{
+	public String getValue() {
+		return "Another hello from Java!";
+	}
+
+	public Object clone() {
+		return this;
+	}
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9747
Context: https://discord.com/channels/732297728826277939/732297837953679412/1339638847864176640
Context: https://discord.com/channels/732297728826277939/732297837953679412/1340011105510101063

While trying to get a MAUI sample running atop NativeAOT, we're observing the following crash:

	E AndroidRuntime: net.dot.jni.internal.JavaProxyThrowable: System.InvalidCastException: Arg_InvalidCastException
	E AndroidRuntime:    at Java.Lang.Object._GetObject[T](IntPtr, JniHandleOwnership) + 0x64
	E AndroidRuntime:    at Microsoft.Maui.WindowOverlay.Initialize() + 0x168

Further investigation shows that the crash is from accessing the `Activity.WindowManager` property:

	namespace Android.App;
	partial class Activity {
	  public virtual unsafe Android.Views.IWindowManager? WindowManager {
	    // Metadata.xml XPath method reference: path="/api/package[@name='android.app']/class[@name='Activity']/method[@name='getWindowManager' and count(parameter)=0]"
	    [Register ("getWindowManager", "()Landroid/view/WindowManager;", "GetGetWindowManagerHandler")]
	    get {
	      const string __id = "getWindowManager.()Landroid/view/WindowManager;";
	      try {
	        var __rm = _members.InstanceMethods.InvokeVirtualObjectMethod (__id, this, null);
	        return global::Java.Lang.Object.GetObject<Android.Views.IWindowManager> (__rm.Handle, JniHandleOwnership.TransferLocalRef);
	      } finally {
	      }
	    }
	  }
	}

`Object.GetObject<T>()` is now a wrapper around
`JniRuntime.JniValueManager.GetPeer()`, so the problem, rephrased, is that this:

	var peer = JniEnvironment.Runtime.ValueManager.GetPeer (
	    ref h,
	    JniObjectReferenceOptions.CopyAndDispose,
	    targetType:typeof (IWindowManager));

returns a value which *does not implement* `IWindowManager`. It was, in fact, returning a `Java.Lang.Object` instance (!).

The cause of the bug is that `JniRuntime.JniValueManager.CreatePeer()` was not checking that the `Type` returned form
`Runtime.TypeManager.GetType(JniTypeSignature)` was compatible with `targetType`; instead, it returned the first type in the inheritance chain that had an activation constructor.  This was `Java.Lang.Object`.

Later, when `_GetObject<T>()` tried to cast the return value of `JniRuntime.JniValueManager.GetPeer()` to `IWindowManager`, it failed.

Fix this by updating `CreatePeer()` to check that the `Type` from `JniRuntime.JniTypeManager.GetType(JniTypeSignature)` is assignable to `targetType`.  This ensures that we *don't* return a `Java.Lang.Object` instance, allowing the cast to succeed.

Update `JniRuntimeJniValueManagerContract` to test these new semantics.