### PR TITLE
[Hello-Java.Base] Add support for Java Callable Wrappers

### DIFF
--- a/build-tools/Java.Interop.Sdk/Sdk/Sdk.targets
+++ b/build-tools/Java.Interop.Sdk/Sdk/Sdk.targets
@@ -64,6 +64,7 @@
 
   <Target Name="_BuildJavaCompileForManagedBinding"
       DependsOnTargets="_CollectJavaCompileForManagedBindingInputs;_JavaCollectJavacRefs"
+      Condition=" '$(_JavaCompileForBindingInputs->Count())' != '0' "
       Inputs="@(_JavaCompileForBindingInputs)"
       Outputs="$(_JavaManagedBindingInput)">
     <PropertyGroup>
@@ -105,6 +106,7 @@
 
   <Target Name="_GenerateApiDescription"
       DependsOnTargets="_CollectClassParseInputs"
+      Condition=" '$(_ClassParseInputs->Count())' != '0' "
       Inputs="@(_ClassParseInputs)"
       Outputs="$(_JavaManagedBindingDir)api.xml">
     <MakeDir Directories="$(_JavaManagedBindingDir)" />
@@ -120,6 +122,7 @@
 
   <Target Name="_GenerateManagedBinding"
       DependsOnTargets="_GenerateApiDescription"
+      Condition=" Exists('$(_JavaManagedBindingDir)api.xml') "
       Inputs="$(_JavaManagedBindingDir)api.xml"
       Outputs="$(_JavaManagedBindingDir)$(AssemblyName).projitems">
     <MakeDir Directories="$(_JavaManagedBindingDir)" />

--- a/samples/Hello-Java.Base/Hello-Java.Base.csproj
+++ b/samples/Hello-Java.Base/Hello-Java.Base.csproj
@@ -7,6 +7,14 @@
     <Nullable>enable</Nullable>
     <StartupObject>Hello.App</StartupObject>
   </PropertyGroup>
+
+  <Import Project="..\..\build-tools\Java.Interop.Sdk\Sdk\Sdk.props" />
+  <!-- Currently needs to be included so that Sdk.targets can find things -->
+  <Import Project="..\..\TargetFrameworkDependentValues.props" />
+
+  <PropertyGroup>
+    <OutputPath>$(MSBuildThisFileDirectory)bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Java.Interop\Java.Interop.csproj" />
@@ -14,5 +22,7 @@
     <ProjectReference Include="..\..\src\Java.Base\Java.Base.csproj" />
     <ProjectReference Include="..\..\tests\TestJVM\TestJVM.csproj" />
   </ItemGroup>
+
+  <Import Project="..\..\build-tools\Java.Interop.Sdk\Sdk\Sdk.targets" />
 
 </Project>

--- a/samples/Hello-Java.Base/Program.cs
+++ b/samples/Hello-Java.Base/Program.cs
@@ -49,9 +49,9 @@ namespace Hello
 				ClassPath   = {
 					Path.Combine (Path.GetDirectoryName (typeof (App).Assembly.Location)!, "Hello-Java.Base.jar"),
 				},
-				TypeManager = new HelloTypeManager (new () {
+				TypeMappings = {
 					[MyJLO.JniTypeName]     = typeof (MyJLO),
-				}),
+				},
 			};
 			builder.AddOption ("-Xcheck:jni");
 
@@ -121,38 +121,6 @@ namespace Hello
 			}
 			foreach (var h in JniRuntime.GetRegisteredRuntimes ()) {
 				Console.WriteLine ("POST: GetCreatedJavaVMs: {0}", h);
-			}
-		}
-	}
-	public class HelloTypeManager : JreTypeManager
-	{
-
-		Dictionary<string, Type> typeMappings;
-
-		public HelloTypeManager (Dictionary<string, Type> typeMappings)
-		{
-			this.typeMappings = typeMappings;
-		}
-
-		protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)
-		{
-			foreach (var t in base.GetTypesForSimpleReference (jniSimpleReference))
-				yield return t;
-			if (typeMappings.TryGetValue (jniSimpleReference, out var target))
-				yield return target;
-		}
-
-		protected override IEnumerable<string> GetSimpleReferences (Type type)
-		{
-			return base.GetSimpleReferences (type)
-				.Concat (CreateSimpleReferencesEnumerator (type));
-		}
-
-		IEnumerable<string> CreateSimpleReferencesEnumerator (Type type)
-		{
-			foreach (var e in typeMappings) {
-				if (e.Value == type)
-					yield return e.Key;
 			}
 		}
 	}

--- a/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/JreRuntime.cs
@@ -35,6 +35,9 @@ namespace Java.Interop {
 		public  TextWriter? JniGlobalReferenceLogWriter {get; set;}
 		public  TextWriter? JniLocalReferenceLogWriter  {get; set;}
 
+		internal    Dictionary<string, Type>?  	typeMappings;
+		public      IDictionary<string, Type>   TypeMappings    => typeMappings ??= new ();
+
 		internal    JvmLibraryHandler?  LibraryHandler  {get; set;}
 
 		public JreRuntimeOptions ()
@@ -85,7 +88,7 @@ namespace Java.Interop {
 			builder.LibraryHandler  = JvmLibraryHandler.Create ();
 
 #if NET
-			builder.TypeManager     ??= new JreTypeManager ();
+			builder.TypeManager     ??= new JreTypeManager (builder.typeMappings);
 #endif  // NET
 
 			bool onMono = Type.GetType ("Mono.Runtime", throwOnError: false) != null;


### PR DESCRIPTION
Update Hello-Java.Base to use Java.Interop.Sdk, so that it (kinda, sorta) "automagically" gets support for generating Java Callable Wrappers as part of its build.

Add a custom `Java.Lang.Object` subclass and use it.

…which in turn requires creating a new `JreTypeManager` subclass to provide the typemap information, because "Java.Interop.Sdk" is not fleshed out enough to provide that information itself.