### PR TITLE
Centralize `<LangVersion>` for `netstandard2.0` projects.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,11 @@
     <DefineConstants>$(DefineConstants);INTERNAL_NULLABLE_ATTRIBUTES</DefineConstants>
   </PropertyGroup>
 
+  <!-- Automatically support the latest C# for netstandard2.0 projects -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <LangVersion>13.0</LangVersion>
+  </PropertyGroup>
+
   <!-- Add Roslyn analyzers NuGet to all projects -->
   <ItemGroup Condition=" '$(DisableRoslynAnalyzers)' != 'True' ">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">

--- a/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
+++ b/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <Import Project="..\..\TargetFrameworkDependentValues.props" />

--- a/src/Java.Interop.Localization/Java.Interop.Localization.csproj
+++ b/src/Java.Interop.Localization/Java.Interop.Localization.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <NeutralLanguage>en</NeutralLanguage>
     <SignAssembly>true</SignAssembly>

--- a/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
+++ b/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
+++ b/src/Java.Interop.Tools.Diagnostics/Java.Interop.Tools.Diagnostics.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <SignAssembly>true</SignAssembly>

--- a/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource.csproj
+++ b/src/Java.Interop.Tools.JavaSource/Java.Interop.Tools.JavaSource.csproj
@@ -2,7 +2,6 @@
   
   <PropertyGroup>
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
-    <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   

--- a/src/Java.Interop.Tools.Maven/Java.Interop.Tools.Maven.csproj
+++ b/src/Java.Interop.Tools.Maven/Java.Interop.Tools.Maven.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>11.0</LangVersion>
-    <Nullable>enable</Nullable>
     <Nullable>enable</Nullable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\product.snk</AssemblyOriginatorKeyFile>

--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -27,8 +27,6 @@
     <OutputPath>$(ToolOutputFullPath)</OutputPath>
     <DocumentationFile>$(ToolOutputFullPath)Java.Interop.xml</DocumentationFile>
     <JNIEnvGenPath>$(BuildToolOutputFullPath)</JNIEnvGenPath>
-    <LangVersion Condition=" '$(JIBuildingForNetCoreApp)' == 'True' ">9.0</LangVersion>
-    <LangVersion Condition=" '$(LangVersion)' == '' ">8.0</LangVersion>
     <Version>$(JICoreLibVersion)</Version>
     <Standalone Condition=" '$(Standalone)' == '' ">true</Standalone>
   </PropertyGroup>


### PR DESCRIPTION
The default `<LangVersion>` for `netstandard2.0` projects is `7.3`, which does not contain many of the niceties we would like to use.  Throughout our history we have updated individual projects to use the latest language features, but this has led to inconsistencies.

Instead, standardize this in `Directory.Build.targets` to use a common C# language version for `netstandard2.0` projects.

Note we standardized on `13.0` (the one that ships with .NET 9) instead of `latest`, as `latest` is discouraged because it can change based on what versions are installed on a machine.