### PR TITLE
[Java.Interop] JNIEnv::NewObject and Replaceable instances

### DIFF
--- a/src/Java.Interop/PublicAPI.Unshipped.txt
+++ b/src/Java.Interop/PublicAPI.Unshipped.txt
@@ -4,7 +4,7 @@ static Java.Interop.JniEnvironment.EndMarshalMethod(ref Java.Interop.JniTransiti
 virtual Java.Interop.JniRuntime.OnEnterMarshalMethod() -> void
 virtual Java.Interop.JniRuntime.OnUserUnhandledException(ref Java.Interop.JniTransition transition, System.Exception! e) -> void
 virtual Java.Interop.JniRuntime.JniTypeManager.GetInvokerTypeCore(System.Type! type) -> System.Type?
-virtual Java.Interop.JniRuntime.JniValueManager.TryCreatePeer(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options, System.Type! type) -> Java.Interop.IJavaPeerable?
+virtual Java.Interop.JniRuntime.JniValueManager.TryConstructPeer(Java.Interop.IJavaPeerable! self, ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions options, System.Type! type) -> bool
 Java.Interop.JavaException.JavaException(ref Java.Interop.JniObjectReference reference, Java.Interop.JniObjectReferenceOptions transfer, Java.Interop.JniObjectReference throwableOverride) -> void
 Java.Interop.JavaException.SetJavaStackTrace(Java.Interop.JniObjectReference peerReferenceOverride = default(Java.Interop.JniObjectReference)) -> void
 Java.Interop.JniRuntime.JniTypeManager.GetInvokerType(System.Type! type) -> System.Type?

--- a/src/Java.Runtime.Environment/Java.Interop/ManagedValueManager.cs
+++ b/src/Java.Runtime.Environment/Java.Interop/ManagedValueManager.cs
@@ -57,9 +57,6 @@ namespace Java.Interop {
 			var r = value.PeerReference;
 			if (!r.IsValid)
 				throw new ObjectDisposedException (value.GetType ().FullName);
-			var o = PeekPeer (value.PeerReference);
-			if (o != null)
-				return;
 
 			if (r.Type != JniObjectReferenceType.Global) {
 				value.SetPeerReference (r.NewGlobalRef ());
@@ -80,7 +77,7 @@ namespace Java.Interop {
 					var p   = peers [i];
 					if (!JniEnvironment.Types.IsSameObject (p.PeerReference, value.PeerReference))
 						continue;
-					if (Replaceable (p)) {
+					if (Replaceable (p, value)) {
 						peers [i] = value;
 					} else {
 						WarnNotReplacing (key, value, p);
@@ -91,11 +88,12 @@ namespace Java.Interop {
 			}
 		}
 
-		static bool Replaceable (IJavaPeerable peer)
+		static bool Replaceable (IJavaPeerable peer, IJavaPeerable value)
 		{
 			if (peer == null)
 				return true;
-			return (peer.JniManagedPeerState & JniManagedPeerStates.Replaceable) == JniManagedPeerStates.Replaceable;
+			return peer.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable) &&
+				!value.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable);
 		}
 
 		void WarnNotReplacing (int key, IJavaPeerable ignoreValue, IJavaPeerable keepValue)

--- a/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
+using System.Runtime.CompilerServices;
 
 using Java.Interop;
 
@@ -35,10 +38,15 @@ namespace Java.InteropTests
 
 		public  bool    InvokedActivationConstructor;
 
+		public  static  CallVirtualFromConstructorDerived?  Intermediate_FromCalledFromConstructor;
+		public  static  CallVirtualFromConstructorDerived?  Intermediate_FromActivationConstructor;
+
 		public CallVirtualFromConstructorDerived (ref JniObjectReference reference, JniObjectReferenceOptions options)
 			: base (ref reference, options)
 		{
 			InvokedActivationConstructor    = true;
+
+			Intermediate_FromActivationConstructor  = this;
 		}
 
 		public bool Called;
@@ -47,6 +55,8 @@ namespace Java.InteropTests
 		{
 			Called      = true;
 			calledValue = value;
+
+			Intermediate_FromCalledFromConstructor  = this;
 		}
 
 		public static unsafe CallVirtualFromConstructorDerived NewInstance (int value)
@@ -54,7 +64,7 @@ namespace Java.InteropTests
 			JniArgumentValue* args = stackalloc JniArgumentValue [1];
 			args [0]    = new JniArgumentValue (value);
 			var o       = _members.StaticMethods.InvokeObjectMethod ("newInstance.(I)Lnet/dot/jni/test/CallVirtualFromConstructorDerived;", args);
-			return JniEnvironment.Runtime.ValueManager.GetValue<CallVirtualFromConstructorDerived> (ref o, JniObjectReferenceOptions.CopyAndDispose);
+			return JniEnvironment.Runtime.ValueManager.GetValue<CallVirtualFromConstructorDerived> (ref o, JniObjectReferenceOptions.CopyAndDispose)!;
 		}
 
 		delegate void CalledFromConstructorMarshalMethod (IntPtr jnienv, IntPtr n_self, int value);
@@ -63,7 +73,7 @@ namespace Java.InteropTests
 			var envp = new JniTransition (jnienv);
 			try {
 				var r_self  = new JniObjectReference (n_self);
-				var self    = JniEnvironment.Runtime.ValueManager.GetValue<CallVirtualFromConstructorDerived>(ref r_self, JniObjectReferenceOptions.Copy);
+				var self    = JniEnvironment.Runtime.ValueManager.GetValue<CallVirtualFromConstructorDerived>(ref r_self, JniObjectReferenceOptions.Copy)!;
 				self.CalledFromConstructor (value);
 				self.DisposeUnlessReferenced ();
 			}

--- a/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/CallVirtualFromConstructorDerived.cs
@@ -27,10 +27,22 @@ namespace Java.InteropTests
 		public  bool    InvokedConstructor;
 
 		public CallVirtualFromConstructorDerived (int value)
-			: base (value)
+			: this (value, useNewObject: false)
+		{
+		}
+
+		public CallVirtualFromConstructorDerived (int value, bool useNewObject)
+			: base (value, useNewObject)
 		{
 			InvokedConstructor = true;
-			if (value != calledValue)
+
+			if (useNewObject && calledValue != 0) {
+				// calledValue was set on a *different* instance! So it's 0 here.
+				throw new ArgumentException (
+						string.Format ("value '{0}' doesn't match expected value '{1}'.", value, 0),
+						"value");
+			}
+			if (!useNewObject && value != calledValue)
 				throw new ArgumentException (
 						string.Format ("value '{0}' doesn't match expected value '{1}'.", value, calledValue),
 						"value");

--- a/tests/Java.Interop-Tests/Java.Interop/InvokeVirtualFromConstructorTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/InvokeVirtualFromConstructorTests.cs
@@ -15,7 +15,7 @@ namespace Java.InteropTests {
 	public class InvokeVirtualFromConstructorTests : JavaVMFixture
 	{
 		[Test]
-		public void CreateManagedInstanceFirst ()
+		public void CreateManagedInstanceFirst_WithAllocObject ()
 		{
 			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
 			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
@@ -39,17 +39,75 @@ namespace Java.InteropTests {
 					"Expected t and registered to be the same instance; " +
 					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
 					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
-			Assert.AreNotSame (t, acIntermediate,
-					"Expected t and registered to be the same instance; " +
-					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
-					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+			Assert.IsNull (acIntermediate,
+					"Activation Constructor should not have been called, because of AllocObject semantics");
 			Assert.AreSame (t, cfIntermediate,
 					"Expected t and cfIntermediate to be the same instance; " +
 					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
 					$"cfIntermediate={RuntimeHelpers.GetHashCode (cfIntermediate).ToString ("x")}");
 
+			Dispose (ref CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor);
+			Dispose (ref CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor);
+		}
+
+		static void Dispose<T> (ref T peer)
+			where T : class, IJavaPeerable
+		{
+			if (peer == null)
+				return;
+
+			peer.Dispose ();
+			peer = null;
+		}
+
+		[Test]
+		public void CreateManagedInstanceFirst_WithNewObject ()
+		{
 			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
 			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
+
+			using var t = new CallVirtualFromConstructorDerived (42, useNewObject: true);
+			Assert.IsFalse (
+					t.Called,
+					"CalledFromConstructor method override was called on a different instance.");
+			Assert.IsFalse (
+					t.InvokedActivationConstructor,
+					"Activation Constructor should not have been called, as calledFromConstructor() is invoked before ManagedPeer.construct().");
+			Assert.IsTrue (
+					t.InvokedConstructor,
+					"(int) constructor should have been called, via ManagedPeer.construct().");
+
+			var registered      = JniRuntime.CurrentRuntime.ValueManager.PeekValue (t.PeerReference);
+			var acIntermediate  = CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor;
+			var cfIntermediate  = CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor;
+
+			Assert.AreSame (t, registered,
+					"Expected t and registered to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+			Assert.IsNotNull (acIntermediate,
+					"Activation Constructor should have been called, because of NewObject");
+			Assert.IsTrue (
+					acIntermediate.Called,
+					"CalledFromConstructor method override should have been called on acIntermediate.");
+			Assert.IsTrue (
+					acIntermediate.InvokedActivationConstructor,
+					"Activation Constructor should have been called on intermediate instance, as calledFromConstructor() is invoked before ManagedPeer.construct().");
+			Assert.AreNotSame (t, acIntermediate,
+					"Expected t and registered to be different instances; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"acIntermediate={RuntimeHelpers.GetHashCode (acIntermediate).ToString ("x")}");
+			Assert.AreNotSame (t, cfIntermediate,
+					"Expected t and cfIntermediate to be different instances; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"cfIntermediate={RuntimeHelpers.GetHashCode (cfIntermediate).ToString ("x")}");
+			Assert.AreSame (acIntermediate, cfIntermediate,
+					"Expected acIntermediate and cfIntermediate to be the same instance; " +
+					$"acIntermediate={RuntimeHelpers.GetHashCode (acIntermediate).ToString ("x")}, " +
+					$"cfIntermediate={RuntimeHelpers.GetHashCode (cfIntermediate).ToString ("x")}");
+
+			Dispose (ref CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor);
+			Dispose (ref CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor);
 		}
 
 		[Test]
@@ -81,14 +139,14 @@ namespace Java.InteropTests {
 			Assert.AreSame (t, acIntermediate,
 					"Expected t and registered to be the same instance; " +
 					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
-					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+					$"acIntermediate={RuntimeHelpers.GetHashCode (acIntermediate).ToString ("x")}");
 			Assert.AreSame (t, cfIntermediate,
 					"Expected t and cfIntermediate to be the same instance; " +
 					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
 					$"cfIntermediate={RuntimeHelpers.GetHashCode (cfIntermediate).ToString ("x")}");
 
-			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
-			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
+			Dispose (ref CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor);
+			Dispose (ref CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor);
 		}
 	}
 }

--- a/tests/Java.Interop-Tests/Java.Interop/InvokeVirtualFromConstructorTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/InvokeVirtualFromConstructorTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 using Java.Interop;
 
@@ -7,25 +8,87 @@ using NUnit.Framework;
 namespace Java.InteropTests {
 
 	[TestFixture]
+#if !__ANDROID__
+	// We want stability around the CallVirtualFromConstructorDerived static fields
+	[NonParallelizable]
+#endif  // !__ANDROID__
 	public class InvokeVirtualFromConstructorTests : JavaVMFixture
 	{
 		[Test]
-		public void InvokeVirtualFromConstructor ()
+		public void CreateManagedInstanceFirst ()
 		{
-			using (var t = new CallVirtualFromConstructorDerived (42)) {
-				Assert.IsTrue (t.Called);
-				Assert.IsNotNull (JniRuntime.CurrentRuntime.ValueManager.PeekValue (t.PeerReference));
-			}
+			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
+			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
+
+			using var t = new CallVirtualFromConstructorDerived (42);
+			Assert.IsTrue (
+					t.Called,
+					"CalledFromConstructor method override should have been called.");
+			Assert.IsFalse (
+					t.InvokedActivationConstructor,
+					"Activation Constructor should have been called, as calledFromConstructor() is invoked before ManagedPeer.construct().");
+			Assert.IsTrue (
+					t.InvokedConstructor,
+					"(int) constructor should have been called, via ManagedPeer.construct().");
+
+			var registered      = JniRuntime.CurrentRuntime.ValueManager.PeekValue (t.PeerReference);
+			var acIntermediate  = CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor;
+			var cfIntermediate  = CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor;
+
+			Assert.AreSame (t, registered,
+					"Expected t and registered to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+			Assert.AreNotSame (t, acIntermediate,
+					"Expected t and registered to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+			Assert.AreSame (t, cfIntermediate,
+					"Expected t and cfIntermediate to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"cfIntermediate={RuntimeHelpers.GetHashCode (cfIntermediate).ToString ("x")}");
+
+			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
+			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
 		}
 
 		[Test]
-		public void ActivationConstructor ()
+		public void CreateJavaInstanceFirst ()
 		{
-			var t = CallVirtualFromConstructorDerived.NewInstance (42);
-			using (t) {
-				Assert.IsTrue (t.InvokedActivationConstructor);
-				Assert.IsTrue (t.InvokedConstructor);
-			}
+			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
+			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
+
+			using var t = CallVirtualFromConstructorDerived.NewInstance (42);
+
+			Assert.IsTrue (
+					t.Called,
+					"CalledFromConstructor method override should have been called.");
+			Assert.IsTrue (
+					t.InvokedActivationConstructor,
+					"Activation Constructor should have been called, as calledFromConstructor() is invoked before ManagedPeer.construct().");
+			Assert.IsTrue (
+					t.InvokedConstructor,
+					"(int) constructor should have been called, via ManagedPeer.construct().");
+
+			var registered      = JniRuntime.CurrentRuntime.ValueManager.PeekValue (t.PeerReference);
+			var acIntermediate  = CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor;
+			var cfIntermediate  = CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor;
+
+			Assert.AreSame (t, registered,
+					"Expected t and registered to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+			Assert.AreSame (t, acIntermediate,
+					"Expected t and registered to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"registered={RuntimeHelpers.GetHashCode (registered).ToString ("x")}");
+			Assert.AreSame (t, cfIntermediate,
+					"Expected t and cfIntermediate to be the same instance; " +
+					$"t={RuntimeHelpers.GetHashCode (t).ToString ("x")}, " +
+					$"cfIntermediate={RuntimeHelpers.GetHashCode (cfIntermediate).ToString ("x")}");
+
+			CallVirtualFromConstructorDerived.Intermediate_FromActivationConstructor    = null;
+			CallVirtualFromConstructorDerived.Intermediate_FromCalledFromConstructor    = null;
 		}
 	}
 }

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
@@ -168,12 +168,16 @@ namespace Java.InteropTests {
 
 			try {
 				var peer1   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
-				Assert.IsTrue (peer1!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
+				Assert.IsTrue (
+						peer1!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable),
+						$"Expected peer1.JniManagedPeerState to have .Replaceable, but was {peer1.JniManagedPeerState}.");
 				var peer2   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
-				Assert.IsTrue (peer2!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
-				Assert.AreNotSame (peer1, peer2);
+				Assert.IsTrue (
+						peer2!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable),
+						$"Expected peer2.JniManagedPeerState to have .Replaceable, but was {peer1.JniManagedPeerState}.");
+				Assert.AreNotSame (peer1, peer2, "Expected peer1 and peer2 to be different instances.");
 				var peeked  = valueManager.PeekPeer (peer2.PeerReference);
-				Assert.AreSame (peer1, peeked);
+				Assert.AreSame (peer1, peeked, "Expected peer1 and peeked to be the same instance.");
 			} finally {
 				JniObjectReference.Dispose (ref lref);
 			}

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
@@ -168,9 +168,9 @@ namespace Java.InteropTests {
 
 			try {
 				var peer1   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
-				Assert.IsTrue (peer1.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
+				Assert.IsTrue (peer1!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
 				var peer2   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
-				Assert.IsTrue (peer2.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
+				Assert.IsTrue (peer2!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
 				Assert.AreNotSame (peer1, peer2);
 				var peeked  = valueManager.PeekPeer (peer2.PeerReference);
 				Assert.AreSame (peer1, peeked);

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
@@ -160,6 +160,26 @@ namespace Java.InteropTests {
 		}
 
 		[Test]
+		public void CreatePeer_ReplaceableDoesNotReplace ()
+		{
+			var v       = new AnotherJavaInterfaceImpl ();
+			var lref    = v.PeerReference.NewLocalRef ();
+			v.Dispose ();
+
+			try {
+				var peer1   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
+				Assert.IsTrue (peer1.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
+				var peer2   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
+				Assert.IsTrue (peer2.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable));
+				Assert.AreNotSame (peer1, peer2);
+				var peeked  = valueManager.PeekPeer (peer2.PeerReference);
+				Assert.AreSame (peer1, peeked);
+			} finally {
+				JniObjectReference.Dispose (ref lref);
+			}
+		}
+
+		[Test]
 		public void CreateValue ()
 		{
 			using (var o = new JavaObject ()) {

--- a/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniRuntimeJniValueManagerContract.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Java.Interop;
@@ -160,6 +161,32 @@ namespace Java.InteropTests {
 		}
 
 		[Test]
+		public void CreatePeer_CreatesNewValueUsingActivationConstructor ()
+		{
+			using var v1    = new AnotherJavaInterfaceImpl ();
+			var lref        = v1.PeerReference.NewLocalRef ();
+			try {
+				using var v2    = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.CopyAndDispose, typeof (AnotherJavaInterfaceImpl));
+				Assert.AreNotSame (v1, v2, "CreatePeer() should create new values");
+			}
+			finally {
+				JniObjectReference.Dispose (ref lref);
+			}
+		}
+
+		[Test]
+		public void CreatePeer_ThrowsIfNoActivationConstructorPresent ()
+		{
+			using var v1    = new GetThis ();
+			var lref        = v1.PeerReference.NewLocalRef ();
+			var ex = Assert.Throws<NotSupportedException> (
+					() => valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.CopyAndDispose, typeof (GetThis)),
+					$"`GetThis` has no activation constructor, so attempting to use it should throw NotSupportedException.");
+			Assert.IsTrue (lref.IsValid, "lref should still be valid");
+			JniObjectReference.Dispose (ref lref);
+		}
+
+		[Test]
 		public void CreatePeer_ReplaceableDoesNotReplace ()
 		{
 			var v       = new AnotherJavaInterfaceImpl ();
@@ -167,17 +194,26 @@ namespace Java.InteropTests {
 			v.Dispose ();
 
 			try {
+				Assert.IsNull (valueManager.PeekPeer (lref), "v.Dispose() should have unregistered the peer.");
 				var peer1   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
 				Assert.IsTrue (
 						peer1!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable),
 						$"Expected peer1.JniManagedPeerState to have .Replaceable, but was {peer1.JniManagedPeerState}.");
+				Assert.AreSame (peer1, valueManager.PeekPeer (lref),
+						$"Expected peer1==PeekValue(peer1.PeerReference); it's the only one that should exist!");
+
 				var peer2   = valueManager.CreatePeer (ref lref, JniObjectReferenceOptions.Copy, typeof (AnotherJavaInterfaceImpl));
 				Assert.IsTrue (
 						peer2!.JniManagedPeerState.HasFlag (JniManagedPeerStates.Replaceable),
-						$"Expected peer2.JniManagedPeerState to have .Replaceable, but was {peer1.JniManagedPeerState}.");
+						$"Expected peer2.JniManagedPeerState to have .Replaceable, but was {peer2.JniManagedPeerState}.");
 				Assert.AreNotSame (peer1, peer2, "Expected peer1 and peer2 to be different instances.");
-				var peeked  = valueManager.PeekPeer (peer2.PeerReference);
-				Assert.AreSame (peer1, peeked, "Expected peer1 and peeked to be the same instance.");
+
+				var peeked  = valueManager.PeekPeer (lref);
+				Assert.AreSame (peer1, peeked,
+						"Expected peer1 and peeked to be the same instance; " +
+						$"peeked={RuntimeHelpers.GetHashCode (peeked).ToString ("x")}, " +
+						$"peer1={RuntimeHelpers.GetHashCode (peer1).ToString ("x")}, " +
+						$"peer2={RuntimeHelpers.GetHashCode (peer2).ToString ("x")}");
 			} finally {
 				JniObjectReference.Dispose (ref lref);
 			}


### PR DESCRIPTION
[Java.Interop] JNIEnv::NewObject and Replaceable instances (#1323)

Context: 3043d890239cf53eb42633430faa417c140c8952
Context: dec35f5453e7452acd00c84eaa91d578e39c710b
Context: https://github.com/dotnet/android/issues/9862
Context: https://github.com/dotnet/android/issues/9862#issuecomment-2705027573
Context: https://github.com/dotnet/android/pull/10004
Context: https://github.com/xamarin/monodroid/commit/326509e56d4e582c53bbe5dfe6d5c741a27f1af5
Context: https://github.com/xamarin/monodroid/commit/940136ebf1318a7c57a855e2728ce2703c0240af

Ever get the feeling that everything is inextricably related?

JNI has two pattens for create an instance of a Java type:

 1. [`JNIEnv::NewObject(jclass clazz, jmethodID methodID, const jvalue* args)`][0]

 2. [`JNIEnv::AllocObject(jclass clazz)`][1] + 
    [`JNIEnv::CallNonvirtualVoidMethod(jobject obj, jclass clazz, jmethodID methodID, const jvalue* args)`][2]

In both patterns:

  * `clazz` is the `java.lang.Class` of the type to create.
  * `methodID` is the constructor to execute
  * `args` are the constructor arguments.

In .NET terms:

  * `JNIEnv::NewObject()` is equivalent to using
    `System.Reflection.ConstructorInfo.Invoke(object?[]?)`, while

  * `JNIEnv::AllocObject()` + `JNIEnv::CallNonvirtualVoidMethod()` is
    equivalent to using
    `System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(Type)` +
    `System.Reflection.MethodBase.Invoke(object?, object?[]?)`.

Why prefer one over the other?

When hand-writing your JNI code, `JNIEnv::NewObject()` is easier.
This is less of a concern when a code generator is used.

The *real* reason to *avoid* `JNIEnv::NewObject()` whenever possible
is the [Java Activation][3] scenario, summarized as the "are you sure
you want to do this?" [^1] scenario of invoking a virtual method from the
constructor:

	class Base {
	  public Base() {
	    VirtualMethod();
	  }
	  public virtual void VirtualMethod() {}
	}

	class Derived : Base {
	  public override void VirtualMethod() {}
	}


Java and C# are identical here: when a constructor invokes a virtual
method, the most derived method implementation is used, which will
occur *before* the constructor of the derived type has *started*
execution.  (With lots of quibbling about field initializers…)

Thus, assume you have a Java `CallVirtualFromConstructorBase` type,
which has its constructor Do The Wrong Thing™ and invoke a virtual
method from the constructor, and that method is overridden in C#?

	// Java
	public class CallVirtualFromConstructorBase {
	  public CallVirtualFromConstructorBase(int value) {
	    calledFromConstructor(value);
	  }
	  public void calledFromConstructor(int value) {
	  }
	}

	// C#
	public class CallVirtualFromConstructorDerived : CallVirtualFromConstructorBase {
	  public CallVirtualFromConstructorDerived(int value)
	    : base (value)
	  {
	  }

	  public override void CalledFromConstructor(int value)
	  {
	  }
	}

What happens with:

	var p = new CallVirtualFromConstructorDerived(42);

The answer depends on whether or not `JNIEnv::NewObject()` is used.

If `JNIEnv::NewObject()` is *not* used (the default!)

 1. `CallVirtualFromConstructorDerived(int)` constructor begins
    execution, immediately calls `base(value)`.

 2. `CallVirtualFromConstructorBase(int)` constructor runs, uses
    `JNIEnv::AllocObject()` to *create* (but not construct!) Java
    `CallVirtualFromConstructorDerived` instance.

 3. `JavaObject.Construct(ref JniObjectReference, JniObjectReferenceOptions)`
    invoked, creating a mapping between the C# instance created in
    (1) and the Java instance created in (2).

 4. `CallVirtualFromConstructorBase(int)` C# constructor calls
    `JniPeerMembers.InstanceMethods.FinishGenericCreateInstance()`,
    which eventually invokes `JNIEnv::CallNonvirtualVoidMethod()`
    with the Java `CallVirtualFromConstructorDerived(int)` ctor.

 5. Java `CallVirtualFromConstructorDerived(int)` constructor invokes
    Java `CallVirtualFromConstructorBase(int)` constructor, which
    invokes `CallVirtualFromConstructorDerived.calledFromConstructor()`.

 6. Marshal method (356485ee) for
    `CallVirtualFromConstructorBase.CalledFromConstructor()` invoked,
    *immediately* calls `JniRuntime.JniValueManager.GetPeer()`
    (e288589d) to obtain an instance upon which to invoke
    `.CalledFromConstructor()`, finds the instance mapping from (3),
    invokes 
    `CallVirtualFromConstructorDerived.CalledFromConstructor()`
    override.

 7. Marshal Method for `CalledFromConstructor()` returns, Java
    `CallVirtualFromConstructorBase(int)` constructor finishes,
    Java `CallVirtualFromConstructorDerived(int)` constructor
    finishes, `JNIEnv::CallNonvirtualVoidMethod()` finishes.

 8. `CallVirtualFromConstructorDerived` instance finishes construction.

If `JNIEnv::NewObject()` is used:

 1. `CallVirtualFromConstructorDerived(int)` constructor begins
    execution, immediately calls `base(value)`.

    Note that this is the first created `CallVirtualFromConstructorDerived`
    instance, but it hasn't been registered yet.

 2. `CallVirtualFromConstructorBase(int)` constructor runs, uses
    `JNIEnv::NewObject()` to construct Java
    `CallVirtualFromConstructorDerived` instance.

 3. `JNIEnv::NewObject()` invokes Java
    `CallVirtualFromConstructorDerived(int)` constructor, which invokes
    `CallVirtualFromConstructorBase(int)` constructor, which invokes
    `CallVirtualFromConstructorDerived.calledFromConstructor()`.

 4. Marshal method (356485ee) for
    `CallVirtualFromConstructorBase.CalledFromConstructor()` invoked,
    *immediately* calls `JniRuntime.JniValueManager.GetPeer()`
    (e288589d) to obtain an instance upon which to invoke
    `.CalledFromConstructor()`.

    Here is where things go "off the rails" compared to the
    `JNIEnv::AllocObject()` code path:

    There is no such instance -- we're still in the middle of
    constructing it! -- so we look for an "activation constructor".

 5. `CallVirtualFromConstructorDerived(ref JniObjectReference, JniObjectReferenceOptions)`
    activation constructor executed.

    This is the *second* `CallVirtualFromConstructorDerived` instance
    created, and registers a mapping from the Java instance that
    we started constructing in (3) to what we'll call the
    "activation intermediary".

    The activation intermediary instance is marked as "Replaceable".

 6. `CallVirtualFromConstructorDerived.CalledFromConstructor()` method
    override invoked on the activation intermediary.

 7. Marshal Method for `CalledFromConstructor()` returns, Java
    `CallVirtualFromConstructorBase(int)` constructor finishes,
    Java `CallVirtualFromConstructorDerived(int)` constructor
    finishes, `JNIEnv::NewObject()` returns instance.

 8. C# `CallVirtualFromConstructorBase(int)` constructor calls
    `JavaObject.Construct(ref JniObjectReference, JniObjectReferenceOptions)`,
    to create a mapping between (3) and (1).

    In .NET for Android, this causes the C# instance created in (1)
    to *replace* the C# instance created in (5), which allows
    "Replaceable" instance to be replaced.

    In dotnet/java-interop, this replacement *didn't* happen, which
    meant that `ValueManager.PeekPeer(p.PeerReference)` would return
    the activation intermediary, *not* `p`, which confuses everyone.

 9. `CallVirtualFromConstructorDerived` instance finishes construction.

For awhile, dotnet/java-interop did not fully support this scenario
around `JNIEnv::NewObject()`.  Additionally, support for using
`JNIEnv::NewObject()` as part of
`JniPeerMembers.JniInstanceMethods.StartCreateInstance()` was
*removed* in dec35f54.

Which brings us to dotnet/android#9862: where there is an observed
"race condition" around `Android.App.Application` subclass creation.
*Two* instances of `AndroidApp` were created, one from the "normal"
app startup:

	at crc647fae2f69c19dcd0d.AndroidApp.n_onCreate(Native Method)
	at crc647fae2f69c19dcd0d.AndroidApp.onCreate(AndroidApp.java:25)
	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1316)

and another from an `androidx.work.WorkerFactory`:

	at mono.android.TypeManager.n_activate(Native Method)
	at mono.android.TypeManager.Activate(TypeManager.java:7)
	at crc647fae2f69c19dcd0d.SyncWorker.<init>(SyncWorker.java:23)
	at java.lang.reflect.Constructor.newInstance0(Native Method)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:343)
	at androidx.work.WorkerFactory.createWorkerWithDefaultFallback(WorkerFactory.java:95)

However, what was odd about this "race condition" was that the
*second* instance created would reliably win!

Further investigation suggested that this was less of a
"race condition" and more a bug in `AndroidValueManager`, wherein when
"Replaceable" instances were created, an existing instance would
*always* be replaced, even if the new instance was also Replaceable!
This feels bananas; yes, Replaceable should be replaceable, but the
expectation was that it would be replaced by *non*-Replaceable
instances, not just any instance that came along later.

Update `JniRuntimeJniValueManagerContract` to add a new
`CreatePeer_ReplaceableDoesNotReplace()` test to codify the desired
semantic that Replaceable instances do not replace Replaceable
instances.

Surprisingly, this new test did not fail on java-interop, as
`ManagedValueManager.AddPeer()` bails early when `PeekPeer()` finds
a value, while `AndroidValueManager.AddPeer()` does not bail early.

An obvious fix for `CreatePeer_ReplaceableDoesNotReplace()` within
dotnet/android would be to adopt the "`AddPeer()` calls `PeekPeer()`"
logic from java-interop.  The problem is that doing so breaks
[`ObjectTest.JnienvCreateInstance_RegistersMultipleInstances()`][5],
as seen in dotnet/android#10004!

`JnienvCreateInstance_RegistersMultipleInstances()` in turn fails
when `PeekPeer()` is used because follows the `JNIEnv::NewObject()`
[construction codepath][6]!

	public CreateInstance_OverrideAbsListView_Adapter (Context context)
	  : base (
	      JNIEnv.CreateInstance (
	        JcwType,
	        "(Landroid/content/Context;)V",
	        new JValue (context)),
	      JniHandleOwnership.TransferLocalRef)
	{
	  AdapterValue = new ArrayAdapter (context, 0);
	}

as `JNIEnv.CreateInstance()` uses `JNIEnv.NewObject()`.

We thus have a conundrum: how do we fix *both*
`CreatePeer_ReplaceableDoesNotReplace()` *and*
`JnienvCreateInstance_RegistersMultipleInstances()`?

The answer is to add proper support for the `JNIEnv::NewObject()`
construction scenario to dotnet/java-interop, which in turn requires
"lowering" the setting of `.Replaceable`.  Previously, we would set
`.Replaceable` *after* the activation constructor was invoked:

	// dotnet/android TypeManager.CreateInstance(), paraphrasing
	var result = CreateProxy (type, handle, transfer);
	result.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
	return result;

This is *too late*, as during execution of the activation constructor,
the instance thinks it *isn't* replaceable, and thus creation of a new
instance via the activation constructor will replace an already
existing replaceable instance; it's not until *after* the constructor
finished executing that we'd set `.Replaceable`.

To fix this, update `JniRuntime.JniValueManager.TryCreatePeerInstance()`
to first create an *uninitialized* instance, set `.Replaceable`, and
*then* invoke the activation constructor.  This allows
`JniRuntime.JniValueManager.AddPeer()` to check to see if the new
value is also replaceable, and ignore the replacement if appropriate.

This in turn requires replacing:

	partial class /* JniRuntime. */ JniValueManager {
	  protected virtual IJavaPeerable? TryCreatePeer ()
	      ref JniObjectReference reference,
	      JniObjectReferenceOptions options,
	      Type type);
	}

with:

	partial class /* JniRuntime. */ JniValueManager {
	  protected virtual bool TryConstructPeer ()
	      IJavaPeerable self,
	      ref JniObjectReference reference,
	      JniObjectReferenceOptions options,
	      Type type);
	}

This is fine because we haven't shipped `TryCreatePeer()` in a stable
release yet.

[^1]:   See also [Framework Design Guidelines > Constructor Design][4]:

    > ❌ AVOID calling virtual members on an object inside its constructor.
    > Calling a virtual member will cause the most derived override to be
    > called, even if the constructor of the most derived type has not
    > been fully run yet.

[0]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#NewObject
[1]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#AllocObject
[2]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#CallNonvirtual_type_Method_routines
[3]: https://learn.microsoft.com/en-us/previous-versions/xamarin/android/internals/architecture#java-activation
[4]: https://learn.microsoft.com/dotnet/standard/design-guidelines/constructor
[5]: https://github.com/dotnet/android/blob/9ad492a42b384519a8b1f1987adae82335536d9c/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs#L68-L79
[6]: https://github.com/dotnet/android/blob/9ad492a42b384519a8b1f1987adae82335536d9c/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs#L151-L160
