### PR TITLE
﻿[JavaCallableWrappers] Remove `was_scanned` from `XmlImporter`/`XmlExporter`.

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/XmlExporter.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/XmlExporter.cs
@@ -17,32 +17,27 @@ public static class XmlExporter
 		OmitXmlDeclaration = true,
 	};
 
-	public static void Export (string filename, IEnumerable<CallableWrapperType> types, bool wasScanned)
+	public static void Export (string filename, IEnumerable<CallableWrapperType> types)
 	{
 		using (var sw = new StreamWriter (filename, false, Encoding.UTF8))
-			Export (sw, types, wasScanned);
+			Export (sw, types);
 	}
 
-	public static void Export (TextWriter sw, IEnumerable<CallableWrapperType> types, bool wasScanned)
+	public static void Export (TextWriter sw, IEnumerable<CallableWrapperType> types)
 	{
 		using (var xml = XmlWriter.Create (sw, settings))
-			Export (xml, types, wasScanned);
+			Export (xml, types);
 	}
 
-	public static void Export (XmlWriter xml, IEnumerable<CallableWrapperType> types, bool wasScanned)
+	public static void Export (XmlWriter xml, IEnumerable<CallableWrapperType> types)
 	{
-		ExportTypes (xml, types, wasScanned);
+		ExportTypes (xml, types);
 	}
 
-	static void ExportTypes (XmlWriter xml, IEnumerable<CallableWrapperType> types, bool wasScanned)
+	static void ExportTypes (XmlWriter xml, IEnumerable<CallableWrapperType> types)
 	{
-		xml.WriteStartElement ("types");
-		xml.WriteAttributeString ("was_scanned", wasScanned.ToString ());
-
 		foreach (var type in types)
 			ExportType (xml, type);
-
-		xml.WriteEndElement ();
 	}
 
 	public static void ExportType (XmlWriter xml, CallableWrapperType type)

--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/XmlImporter.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/XmlImporter.cs
@@ -11,26 +11,36 @@ namespace Java.Interop.Tools.JavaCallableWrappers.Adapters;
 
 public static class XmlImporter
 {
-	public static List<CallableWrapperType> Import (string filename, out bool wasScanned)
+	public static List<CallableWrapperType> Import (string filename)
 	{
 		using (var sr = new StreamReader (filename, Encoding.UTF8))
-			return Import (sr, out wasScanned);
+			return Import (sr);
 	}
 
-	public static List<CallableWrapperType> Import (TextReader sr, out bool wasScanned)
+	public static List<CallableWrapperType> Import (TextReader sr)
 	{
 		using (var xml = XmlReader.Create (sr))
-			return Import (xml, out wasScanned);
+			return Import (xml);
 	}
 
-	public static List<CallableWrapperType> Import (XmlReader xml, out bool wasScanned)
+	public static List<CallableWrapperType> Import (XmlReader xml)
 	{
 		var doc = XDocument.Load (xml);
 
 		var types = new List<CallableWrapperType> ();
-		wasScanned = doc.Root.GetAttributeOrDefault ("was_scanned", false);
 
 		foreach (var type in doc.Root.Elements ("type"))
+			types.Add (ImportType (type));
+
+		return types;
+	}
+
+
+	public static List<CallableWrapperType> Import (XElement xml)
+	{
+		var types = new List<CallableWrapperType> ();
+
+		foreach (var type in xml.Elements ("type"))
 			types.Add (ImportType (type));
 
 		return types;


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9930

Make a few tweaks to JCW serialization for https://github.com/dotnet/android/pull/9930:
- We no longer need `was_scanned`, we now write a zero byte file to indicate a file was not scanned.
- Add an overload to import from an `XElement`, as the full `.jlo.xml` file now contains additional non-JCW data.