### PR TITLE
[Java.Interop] Use `Class.forName()` as fallback to load Java classes

### DIFF
--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -32,7 +32,7 @@ namespace Java.Interop
 				using (var t = new JniType ("java/lang/Class")) {
 					Class_reference = t.PeerReference.NewGlobalRef ();
 					Class_getName   = t.GetInstanceMethod ("getName", "()Ljava/lang/String;");
-					Class_forName   = t.GetStaticMethod ("forName", "(Ljava/lang/String;)Ljava/lang/Class;");
+					Class_forName   = t.GetStaticMethod ("forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;");
 				}
 			}
 
@@ -63,8 +63,10 @@ namespace Java.Interop
 
 				if (Class_forName.IsValid) {
 					var java    = info.ToJavaName (classname);
-					var __args  = stackalloc JniArgumentValue [1];
+					var __args  = stackalloc JniArgumentValue [3];
 					__args [0]  = new JniArgumentValue (java);
+					__args [1]  = new JniArgumentValue (true);  // initialize the class
+					__args [2]  = new JniArgumentValue (info.Runtime.ClassLoader);
 
 					c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
 					JniObjectReference.Dispose (ref java);

--- a/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
+++ b/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs
@@ -24,11 +24,15 @@ namespace Java.Interop
 			};
 
 			static  readonly    JniMethodInfo           Class_getName;
+			static  readonly    JniMethodInfo           Class_forName;
+			static  readonly    JniObjectReference      Class_reference;
 
 			static Types ()
 			{
 				using (var t = new JniType ("java/lang/Class")) {
+					Class_reference = t.PeerReference.NewGlobalRef ();
 					Class_getName   = t.GetInstanceMethod ("getName", "()Ljava/lang/String;");
+					Class_forName   = t.GetStaticMethod ("forName", "(Ljava/lang/String;)Ljava/lang/Class;");
 				}
 			}
 
@@ -57,12 +61,12 @@ namespace Java.Interop
 				LogCreateLocalRef (findClassThrown);
 				var pendingException    = info.Runtime.GetExceptionForThrowable (ref findClassThrown, JniObjectReferenceOptions.CopyAndDispose);
 
-				if (info.Runtime.ClassLoader_LoadClass != null) {
+				if (Class_forName.IsValid) {
 					var java    = info.ToJavaName (classname);
 					var __args  = stackalloc JniArgumentValue [1];
 					__args [0]  = new JniArgumentValue (java);
 
-					c = RawCallObjectMethodA (info.EnvironmentPointer, out thrown, info.Runtime.ClassLoader.Handle, info.Runtime.ClassLoader_LoadClass.ID, (IntPtr) __args);
+					c = RawCallStaticObjectMethodA (info.EnvironmentPointer, out thrown, Class_reference.Handle, Class_forName.ID, (IntPtr) __args);
 					JniObjectReference.Dispose (ref java);
 					if (thrown == IntPtr.Zero) {
 						(pendingException as IJavaPeerable)?.Dispose ();
@@ -169,12 +173,12 @@ namespace Java.Interop
 #endif  // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
 			}
 
-			static IntPtr RawCallObjectMethodA (IntPtr env, out IntPtr thrown, IntPtr instance, IntPtr jmethodID, IntPtr args)
+			static IntPtr RawCallStaticObjectMethodA (IntPtr env, out IntPtr thrown, IntPtr clazz, IntPtr jmethodID, IntPtr args)
 			{
 #if FEATURE_JNIENVIRONMENT_JI_PINVOKES
-				return NativeMethods.java_interop_jnienv_call_object_method_a (env, out thrown, instance, jmethodID, args);
+				return NativeMethods.java_interop_jnienv_call_static_object_method_a (env, out thrown, clazz, instance, jmethodID, args);
 #elif FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS
-				var r   = JniNativeMethods.CallObjectMethodA (env, instance, jmethodID, args);
+				var r   = JniNativeMethods.CallStaticObjectMethodA (env, clazz, jmethodID, args);
 				thrown  = JniNativeMethods.ExceptionOccurred (env);
 				return r;
 #else   // FEATURE_JNIENVIRONMENT_JI_FUNCTION_POINTERS

--- a/src/Java.Interop/Java.Interop/JniRuntime.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.cs
@@ -58,7 +58,9 @@ namespace Java.Interop
 			public  IntPtr                      InvocationPointer           {get; set;}
 			public  IntPtr                      EnvironmentPointer          {get; set;}
 
+			[Obsolete ("No longer supported; Class.forName() is now used instead")]
 			public  JniObjectReference          ClassLoader                 {get; set;}
+			[Obsolete ("No longer supported; Class.forName() is now used instead")]
 			public  IntPtr                      ClassLoader_LoadClass_id    {get; set;}
 
 			public  JniObjectReferenceManager?  ObjectReferenceManager      {get; set;}
@@ -204,29 +206,6 @@ namespace Java.Interop
 			}
 			var env     = new JniEnvironmentInfo (envp, this);
 			JniEnvironment.SetEnvironmentInfo (env);
-
-			ClassLoader = options.ClassLoader;
-			if (options.ClassLoader_LoadClass_id != IntPtr.Zero) {
-				ClassLoader_LoadClass   = new JniMethodInfo (options.ClassLoader_LoadClass_id, isStatic: false);
-			}
-
-			if (ClassLoader.IsValid) {
-				ClassLoader = ClassLoader.NewGlobalRef ();
-			}
-
-			if (!ClassLoader.IsValid || ClassLoader_LoadClass == null) {
-				using (var t = new JniType ("java/lang/ClassLoader")) {
-					if (!ClassLoader.IsValid) {
-						var m       = t.GetStaticMethod ("getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-						var loader  = JniEnvironment.StaticMethods.CallStaticObjectMethod (t.PeerReference, m);
-						ClassLoader = loader.NewGlobalRef ();
-						JniObjectReference.Dispose (ref loader);
-					}
-					if (ClassLoader_LoadClass == null) {
-						ClassLoader_LoadClass   = t.GetInstanceMethod ("loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
-					}
-				}
-			}
 
 #if !XA_JI_EXCLUDE
 			ManagedPeer.Init ();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/java-interop/issues/23

Context: https://github.com/dotnet/android/commit/aba272691f96fa179e7ea29196760d0dcb82cf16
Context: b4d44e4b3590a6a5a5e9bf4a0044eb2acf17bef6
Context: https://github.com/xamarin/monodroid/commit/ed984a3a0bfbe71f6499a7855c647b5bc2b28466
Context: https://github.com/dotnet/android/issues/7616

Commit b4d44e4b noted:

> Android is..."special", in that not all threads get the same
> ClassLoader behavior. Specifically, *managed* threads --
> System.Threading.Thread instances -- get a different ClassLoader than
> the main/UI thread on Android. (Untested, but the ClassLoader *may*
> behave sanely if you use a java.lang.Thread instance instead. But who
> wants to use java.lang.Thread instances...?)

dotnet/android#7616 provided additional context: `JNIEnv::FindClass()` behavior *is* tied to the thread that calls it, and one of the knock-on effects is that `Java.Lang.JavaSystem.LoadLibrary("MyLib")` doesn't work properly when invoked from a new `System.Threading.Thread` thread.

Which brings us to xamarin/mondroid@ed984a3a, which updated then Xamarin.Android to use [`java.lang.Class.forName(String)`][0] instead of [`ClassLoader.loadClass(String)`][1] because the "real" JDK cannot use `ClassLoader.loadClass(String)` to load array types:

	Class c1 = Class.forName("[Ljava.lang.String;");    // works
	Class c2 = ClassLoader.getSystemClassLoader()
	    .loadClass("[Ljava.lang.String;");              // throws java.lang.ClassNotFoundException

	Class c3 = Class.forName("[I");                     // works; array of int
	Class c4 = ClassLoader.getSystemClassLoader()
	    .loadClass("[I");                               // throws java.lang.ClassNotFoundException

Using `ClassLoader.loadClass(String)` to load array types works on Android, presumably as an undocumented implementation detail, but as xamarin/monodroid@ed984a3a was trying to get things working within the (now dead) Android Designer -- which ran using a Desktop JDK -- Android-specific extensions were not available.

Update `JniEnvironment.Types` to use `Class.forName(String)` instead of `ClassLoader.loadClass(String)` to load Java classes, as a fallback for when `JNIEnv::FindClass()` fails to find the class.

[0]: https://developer.android.com/reference/java/lang/Class#forName(java.lang.String)
[1]: https://developer.android.com/reference/java/lang/ClassLoader#loadClass(java.lang.String)