### PR TITLE
[Java.Interop] Skip irrelevant types returned from TypeManager.GetTypes (sig)

### DIFF
--- a/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
+++ b/src/Java.Interop/Java.Interop/JniRuntime.JniValueManager.cs
@@ -385,8 +385,12 @@ namespace Java.Interop
 				[return: DynamicallyAccessedMembers (Constructors)]
 				Type? GetTypeAssignableTo (JniTypeSignature sig, Type targetType)
 				{
-					return Runtime.TypeManager.GetTypes (sig)
-						.FirstOrDefault (targetType.IsAssignableFrom);
+					foreach (var t in Runtime.TypeManager.GetTypes (sig)) {
+						if (targetType.IsAssignableFrom (t)) {
+							return t;
+						}
+					}
+					return null;
 				}
 			}
 

--- a/tests/Java.Base-Tests/Java.Base/JavaVMFixture.cs
+++ b/tests/Java.Base-Tests/Java.Base/JavaVMFixture.cs
@@ -17,6 +17,7 @@ namespace Java.BaseTests {
 			var c = new TestJVM (
 					jars:           new[]{ "java.base-tests.jar" },
 					typeMappings:   new Dictionary<string, Type> () {
+						["java/lang/Float"]         = typeof (Java.Lang.Float),
 						["example/MyIntConsumer"]   = typeof (MyIntConsumer),
 						["example/MyRunnable"]      = typeof (MyRunnable),
 						[JavaInvoker.JniTypeName]   = typeof (JavaInvoker),

--- a/tests/Java.Base-Tests/Java.Base/JniRuntimeJniValueManagerContractExtras.cs
+++ b/tests/Java.Base-Tests/Java.Base/JniRuntimeJniValueManagerContractExtras.cs
@@ -12,16 +12,16 @@ public class JniRuntimeJniValueManagerContractExtras : JavaVMFixture {
 	[Test]
 	public void CreatePeer_FloatIsNotNullableSingle ()
 	{
-        JniObjectReference float_ref;
-        using (var value = new Java.Lang.Float (1.0f)) {
-            float_ref = value.PeerReference.NewLocalRef ();
-        }
-        try {
-            var peer = JniEnvironment.Runtime.ValueManager.CreatePeer (ref float_ref, JniObjectReferenceOptions.Copy, targetType: null);
-            Assert.IsNotNull (peer, "Could not create Java.Lang.Float peer!");
-            Assert.AreEqual (typeof (Java.Lang.Float), peer.GetType (), $"Peer type mismatch: expected Java.Lang.Float, got {peer.GetType ()}");
-        } finally {
-            JniObjectReference.Dispose (ref float_ref);
-        }
+		JniObjectReference float_ref;
+		using (var value = new Java.Lang.Float (1.0f)) {
+			float_ref   = value.PeerReference.NewLocalRef ();
+		}
+		try {
+			var peer    = JniEnvironment.Runtime.ValueManager.CreatePeer (ref float_ref, JniObjectReferenceOptions.Copy, targetType: null);
+			Assert.IsNotNull (peer, "Could not create Java.Lang.Float peer!");
+			Assert.AreEqual (typeof (Java.Lang.Float), peer.GetType (), $"Peer type mismatch: expected Java.Lang.Float, got {peer.GetType ()}");
+		} finally {
+			JniObjectReference.Dispose (ref float_ref);
+		}
 	}
 }

--- a/tests/Java.Base-Tests/Java.Base/JniRuntimeJniValueManagerContractExtras.cs
+++ b/tests/Java.Base-Tests/Java.Base/JniRuntimeJniValueManagerContractExtras.cs
@@ -1,0 +1,27 @@
+using System;
+
+using Java.Interop;
+
+using NUnit.Framework;
+
+namespace Java.BaseTests;
+
+[TestFixture]
+public class JniRuntimeJniValueManagerContractExtras : JavaVMFixture {
+
+	[Test]
+	public void CreatePeer_FloatIsNotNullableSingle ()
+	{
+        JniObjectReference float_ref;
+        using (var value = new Java.Lang.Float (1.0f)) {
+            float_ref = value.PeerReference.NewLocalRef ();
+        }
+        try {
+            var peer = JniEnvironment.Runtime.ValueManager.CreatePeer (ref float_ref, JniObjectReferenceOptions.Copy, targetType: null);
+            Assert.IsNotNull (peer, "Could not create Java.Lang.Float peer!");
+            Assert.AreEqual (typeof (Java.Lang.Float), peer.GetType (), $"Peer type mismatch: expected Java.Lang.Float, got {peer.GetType ()}");
+        } finally {
+            JniObjectReference.Dispose (ref float_ref);
+        }
+	}
+}

--- a/tests/Java.Base-Tests/Java.Base/JniRuntimeJniValueManagerContractExtras.cs
+++ b/tests/Java.Base-Tests/Java.Base/JniRuntimeJniValueManagerContractExtras.cs
@@ -13,13 +13,18 @@ public class JniRuntimeJniValueManagerContractExtras : JavaVMFixture {
 	public void CreatePeer_FloatIsNotNullableSingle ()
 	{
 		JniObjectReference float_ref;
+#pragma warning disable CS0618
 		using (var value = new Java.Lang.Float (1.0f)) {
 			float_ref   = value.PeerReference.NewLocalRef ();
 		}
+#pragma warning restore CS0618
 		try {
 			var peer    = JniEnvironment.Runtime.ValueManager.CreatePeer (ref float_ref, JniObjectReferenceOptions.Copy, targetType: null);
 			Assert.IsNotNull (peer, "Could not create Java.Lang.Float peer!");
-			Assert.AreEqual (typeof (Java.Lang.Float), peer.GetType (), $"Peer type mismatch: expected Java.Lang.Float, got {peer.GetType ()}");
+			Assert.AreEqual (
+					typeof (Java.Lang.Float),
+					peer!.GetType (),
+					$"Peer type mismatch: expected Java.Lang.Float, got {peer.GetType ()}");
 		} finally {
 			JniObjectReference.Dispose (ref float_ref);
 		}

--- a/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JniTypeManagerTests.cs
@@ -33,6 +33,8 @@ namespace Java.InteropTests
 			AssertGetJniTypeInfoForType (typeof (bool),     "Z",    true,   0);
 			AssertGetJniTypeInfoForType (typeof (void),     "V",    true,   0);
 
+			AssertGetJniTypeInfoForType (typeof (float?),      "java/lang/Float",   true,   0);
+
 			AssertGetJniTypeInfoForType (typeof (JavaObject),  "java/lang/Object",  false,  0);
 
 			// Enums are their underlying type
@@ -130,6 +132,7 @@ namespace Java.InteropTests
 			Assert.AreEqual (typeof (float),    GetType ("F"));
 			Assert.AreEqual (typeof (double),   GetType ("D"));
 			Assert.AreEqual (typeof (string),   GetType ("java/lang/String"));
+			Assert.AreEqual (typeof (float?),   GetType ("java/lang/Float"));
 			Assert.AreEqual (null,              GetType ("com/example/does/not/exist"));
 			Assert.AreEqual (null,              GetType ("Lcom/example/does/not/exist;"));
 			Assert.AreEqual (null,              GetType ("[Lcom/example/does/not/exist;"));

--- a/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
@@ -108,6 +108,11 @@ namespace Java.InteropTests
 		{
 		}
 
+		[JavaCallable ("staticActionNullableFloat", Signature="(Ljava/lang/Float;)V")]
+		public static void StaticActionNullableFloat (float? f)
+		{
+		}
+
 		[JavaCallable ("staticFuncThisMethodTakesLotsOfParameters", Signature="(ZBCSIJFDLjava/lang/Object;Ljava/lang/String;Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/Object;DFJ)Z")]
 		public static bool StaticFuncThisMethodTakesLotsOfParameters (
 				bool                a,

--- a/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/ExportTest.cs
@@ -108,7 +108,7 @@ namespace Java.InteropTests
 		{
 		}
 
-		[JavaCallable ("staticActionNullableFloat", Signature="(Ljava/lang/Float;)V")]
+		// TODO: [JavaCallable ("staticActionNullableFloat", Signature="(Ljava/lang/Float;)V")]
 		public static void StaticActionNullableFloat (float? f)
 		{
 		}

--- a/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -22,7 +22,7 @@ namespace Java.InteropTests
 				var methods = CreateBuilder ()
 					.GetExportedMemberRegistrations (typeof (ExportTest))
 					.ToList ();
-				Assert.AreEqual (11, methods.Count);
+				Assert.AreEqual (12, methods.Count);
 
 				Assert.AreEqual ("n_InstanceAction",    methods [0].Name);
 				Assert.AreEqual ("()V",                 methods [0].Signature);

--- a/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
+++ b/tests/Java.Interop.Export-Tests/Java.Interop/MarshalMemberBuilderTest.cs
@@ -22,7 +22,7 @@ namespace Java.InteropTests
 				var methods = CreateBuilder ()
 					.GetExportedMemberRegistrations (typeof (ExportTest))
 					.ToList ();
-				Assert.AreEqual (12, methods.Count);
+				Assert.AreEqual (11, methods.Count);
 
 				Assert.AreEqual ("n_InstanceAction",    methods [0].Name);
 				Assert.AreEqual ("()V",                 methods [0].Signature);

--- a/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/ExportType.java
+++ b/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/ExportType.java
@@ -103,7 +103,7 @@ public class ExportType
 
 		staticActionInt (1);
 		staticActionFloat (2.0f);
-		staticActionNullableFloat (3.0f);
+		// staticActionNullableFloat (3.0f);
 
 		boolean r = staticFuncThisMethodTakesLotsOfParameters (
 				false,
@@ -145,8 +145,8 @@ public class ExportType
 	public          void    staticActionFloat (float f) {n_StaticActionFloat (f);}
 	private native  void    n_StaticActionFloat (float f);
 
-	public          void    staticActionNullableFloat (Float f) {n_StaticActionNullableFloat (f);}
-	private native  void    n_StaticActionNullableFloat (Float f);
+	// public          void    staticActionNullableFloat (Float f) {n_StaticActionNullableFloat (f);}
+	// private native  void    n_StaticActionNullableFloat (Float f);
 
 	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
 

--- a/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/ExportType.java
+++ b/tests/Java.Interop.Export-Tests/java/net/dot/jni/test/ExportType.java
@@ -103,6 +103,7 @@ public class ExportType
 
 		staticActionInt (1);
 		staticActionFloat (2.0f);
+		staticActionNullableFloat (3.0f);
 
 		boolean r = staticFuncThisMethodTakesLotsOfParameters (
 				false,
@@ -143,6 +144,9 @@ public class ExportType
 
 	public          void    staticActionFloat (float f) {n_StaticActionFloat (f);}
 	private native  void    n_StaticActionFloat (float f);
+
+	public          void    staticActionNullableFloat (Float f) {n_StaticActionNullableFloat (f);}
+	private native  void    n_StaticActionNullableFloat (Float f);
 
 	ArrayList<Object>       managedReferences     = new ArrayList<Object>();
 


### PR DESCRIPTION
The `JniValueManager.CreatePeerInstance` method did not work correctly when the input was an object of type `java/lang/Float`. In this case, the `Runtime.TypeManager.GetType (sig)` call returned `System.Single?`, which is not assignable from the target type (`Java.Lang.Object`).

The problem was that `GetType (sig)` was implemented in such a way that it would return the first value of `GetTypes (sig)`. For built-in types, such as floats, we have a dictionary with mapping to their .NET counterparts in `JniRuntime.JniBuiltinSimpleReferenceToType`. This caused that `GetType (sig)` returned `float?`, while `GetTypes (sig)` returns also `Java.Lang.Float`. Only the latter is suitable for `CreatePeerInstance`.