### PR TITLE
[Java.Interop-Tests] use `#if !NO_GC_BRIDGE_SUPPORT` for some tests

### DIFF
--- a/tests/Java.Interop-Tests/Java.Interop/JavaManagedGCBridgeTests.cs
+++ b/tests/Java.Interop-Tests/Java.Interop/JavaManagedGCBridgeTests.cs
@@ -11,6 +11,7 @@ namespace Java.InteropTests {
 	[TestFixture]
 	public class JavaManagedGCBridgeTests : JavaVMFixture {
 
+#if !NO_GC_BRIDGE_SUPPORT
 		// https://github.com/mono/mono/blob/98d2314/mono/tests/sgen-bridge-xref.cs
 		[Test]
 		public void CrossReferences ()
@@ -33,6 +34,7 @@ namespace Java.InteropTests {
 				Assert.IsNotNull (b);
 			}
 		}
+#endif  // !NO_GC_BRIDGE_SUPPORT
 
 		static void SetupLinks (JavaObjectArray<CrossReferenceBridge> array, out WeakReference<CrossReferenceBridge> root, out WeakReference<CrossReferenceBridge> child)
 		{


### PR DESCRIPTION
Fixes a failure on NativeAOT such as:

    05-01 16:44:12.720  9955  9974 I NUnit   : JavaManagedGCBridgeTests
    05-01 16:44:12.721  9955  9974 I NUnit   : CrossReferences
    --------- beginning of crash
    05-01 16:44:12.723  9955  9999 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 9999 (Thread-13), pid 9955 (droid.NET_Tests)
    05-01 16:44:12.753 10002 10002 I crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
    05-01 16:44:12.754  1875  1875 I /system/bin/tombstoned: received crash request for pid 9999
    05-01 16:44:12.755 10002 10002 I crash_dump64: performing dump of process 9955 (target tid = 9999)
    05-01 16:44:12.758 10002 10002 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
    05-01 16:44:12.759 10002 10002 F DEBUG   : Build fingerprint: 'Android/sdk_phone_x86_64/generic_x86_64:10/QSR1.210820.001/7663313:userdebug/test-keys'
    05-01 16:44:12.759 10002 10002 F DEBUG   : Revision: '0'
    05-01 16:44:12.759 10002 10002 F DEBUG   : ABI: 'x86_64'
    05-01 16:44:12.759 10002 10002 F DEBUG   : Timestamp: 2025-05-01 16:44:12+0000
    05-01 16:44:12.759 10002 10002 F DEBUG   : pid: 9955, tid: 9999, name: Thread-13  >>> Mono.Android.NET_Tests <<<
    05-01 16:44:12.759 10002 10002 F DEBUG   : uid: 10120
    05-01 16:44:12.759 10002 10002 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
    05-01 16:44:12.759 10002 10002 F DEBUG   :     rax 0000000000000000  rbx 00000000000026e3  rcx 00007db8e65163f8  rdx 0000000000000006
    05-01 16:44:12.759 10002 10002 F DEBUG   :     r8  00007d777538f770  r9  0000000000000000  r10 00007d777538f740  r11 0000000000000246
    05-01 16:44:12.759 10002 10002 F DEBUG   :     r12 00007db80e224f9c  r13 0000000000000916  r14 00007d777538f7c8  r15 000000000000270f
    05-01 16:44:12.759 10002 10002 F DEBUG   :     rdi 00000000000026e3  rsi 000000000000270f
    05-01 16:44:12.760 10002 10002 F DEBUG   :     rbp 00007d777538f810  rsp 00007d777538f738  rip 00007db8e65163f8
    05-01 16:44:12.810 10002 10002 F DEBUG   :
    05-01 16:44:12.810 10002 10002 F DEBUG   : backtrace:
    05-01 16:44:12.810 10002 10002 F DEBUG   :       #00 pc 00000000000943f8  /apex/com.android.runtime/lib64/bionic/libc.so (syscall+24) (BuildId: b5c6019a3b4ea61b5e9a2f56319b584e)
    05-01 16:44:12.810 10002 10002 F DEBUG   :       #01 pc 0000000000097146  /apex/com.android.runtime/lib64/bionic/libc.so (abort+182) (BuildId: b5c6019a3b4ea61b5e9a2f56319b584e)
    05-01 16:44:12.810 10002 10002 F DEBUG   :       #02 pc 0000000000016978  /data/app/Mono.Android.NET_Tests-vt_TJEuikFfGaDBlx7t6GQ==/split_config.x86_64.apk

Which crashes the entire test suite, so we don't know if further tests pass or fail.