### PR TITLE
Pull in updated `NullableAttributes` from `dotnet/runtime`.

### DIFF
--- a/src/utils/NullableAttributes.cs
+++ b/src/utils/NullableAttributes.cs
@@ -130,4 +130,71 @@ namespace System.Diagnostics.CodeAnalysis
 		/// <summary>Gets the condition parameter value.</summary>
 		public bool ParameterValue { get; }
 	}
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+	internal
+#else
+    public
+#endif
+	    sealed class MemberNotNullAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with a field or property member.</summary>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute (string member) => Members = new [] { member };
+
+		/// <summary>Initializes the attribute with the list of field and property members.</summary>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullAttribute (params string [] members) => Members = members;
+
+		/// <summary>Gets field or property member names.</summary>
+		public string [] Members { get; }
+	}
+
+	/// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
+	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+	internal
+#else
+    public
+#endif
+	    sealed class MemberNotNullWhenAttribute : Attribute
+	{
+		/// <summary>Initializes the attribute with the specified return value condition and a field or property member.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="member">
+		/// The field or property member that is promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute (bool returnValue, string member)
+		{
+			ReturnValue = returnValue;
+			Members = new [] { member };
+		}
+
+		/// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>
+		/// <param name="returnValue">
+		/// The return value condition. If the method returns this value, the associated parameter will not be null.
+		/// </param>
+		/// <param name="members">
+		/// The list of field and property members that are promised to be not-null.
+		/// </param>
+		public MemberNotNullWhenAttribute (bool returnValue, params string [] members)
+		{
+			ReturnValue = returnValue;
+			Members = members;
+		}
+
+		/// <summary>Gets the return value condition.</summary>
+		public bool ReturnValue { get; }
+
+		/// <summary>Gets field or property member names.</summary>
+		public string [] Members { get; }
+	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/blob/2a1595eb83ec3b520d18b44236ae265d5a433640/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs

Pull in a newer copy of `NullableAttributes.cs` from [`dotnet/runtime`](https://github.com/dotnet/runtime/blob/2a1595eb83ec3b520d18b44236ae265d5a433640/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/NullableAttributes.cs) that contains `[MemberNotNull]` and `[MemberNotNullWhen]`.