### PR TITLE
[Java.Interop.Tools.JavaCallableWrappers] check if type cannot be resolved

### DIFF
--- a/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs
+++ b/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs
@@ -63,6 +63,8 @@ public class CecilImporter
 		// Implemented interfaces
 		foreach (var ifaceInfo in type.Interfaces) {
 			var iface = resolver.Resolve (ifaceInfo.InterfaceType);
+			if (iface is null)
+				continue;
 
 			if (!CecilExtensions.GetTypeRegistrationAttributes (iface).Any ())
 				continue;


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/issues/1347

A combination of NuGet packages can result in the error:

    C:\Program Files\dotnet\packs\Microsoft.Android.Sdk.Windows\35.0.78\tools\Xamarin.Android.Common.targets(1503,3): error XAGJS7000:
      System.AggregateException: One or more errors occurred. (Object reference not set to an instance of an object.)
       ---> System.NullReferenceException: Object reference not set to an instance of an object.
         at Java.Interop.Tools.Cecil.CustomAttributeProviderRocks.GetCustomAttributes(ICustomAttributeProvider item, String attribute_fullname)+MoveNe
      xt() in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.Cecil/Java.Interop.Tools.Cecil/CustomAttributeProvid
      erRocks.cs:line 30
         at System.Linq.Enumerable.IEnumerableSelectIterator`2.MoveNext()
         at System.Linq.Enumerable.IEnumerableWhereSelectIterator`2.MoveNext()
         at Java.Interop.Tools.JavaCallableWrappers.Utilities.CecilExtensions.GetTypeRegistrationAttributes(ICustomAttributeProvider p)+MoveNext() in
      /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers
      /CecilExtensions.cs:line 159
         at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
         at Java.Interop.Tools.JavaCallableWrappers.Adapters.CecilImporter.CreateType(TypeDefinition type, IMetadataResolver resolver, CallableWrapper
      ReaderOptions options, String outerType) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrap
      pers/Java.Interop.Tools.JavaCallableWrappers.Adapters/CecilImporter.cs:line 67
         at Java.Interop.Tools.JavaCallableWrappers.Adapters.CecilImporter.CreateType(TypeDefinition type, IMetadataResolver resolver, CallableWrapper
      ReaderOptions options) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.
      Tools.JavaCallableWrappers.Adapters/CecilImporter.cs:line 19
         at Xamarin.Android.Tasks.JCWGenerator.CreateGenerator(TypeDefinition type, MarshalMethodsClassifier classifier, String monoInit, Boolean hasE
      xportReference, String applicationJavaClass) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs
      :line 183
         at Xamarin.Android.Tasks.JCWGenerator.ProcessTypes(Boolean generateCode, String androidSdkPlatform, MarshalMethodsClassifier classifier, Stri
      ng outputPath, String applicationJavaClass) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs:
      line 110
         at Xamarin.Android.Tasks.JCWGenerator.GenerateAndClassify(String androidSdkPlatform, String outputPath, String applicationJavaClass) in /User
      s/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Utilities/JCWGenerator.cs:line 83
         at Xamarin.Android.Tasks.GenerateJavaStubs.GenerateJavaSourcesAndMaybeClassifyMarshalMethods(AndroidTargetArch arch, Dictionary`2 assemblies,
       Dictionary`2 userAssemblies, Boolean useMarshalMethods, Boolean generateJavaCode) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android
      .Build.Tasks/Tasks/GenerateJavaStubs.cs:line 386
         at Xamarin.Android.Tasks.GenerateJavaStubs.<>c__DisplayClass146_0.<Run>b__0(KeyValuePair`2 kvp) in /Users/runner/work/1/s/xamarin-android/src
      /Xamarin.Android.Build.Tasks/Tasks/GenerateJavaStubs.cs:line 202
         at System.Threading.Tasks.Parallel.<>c__DisplayClass43_0`2.<PartitionerForEachWorker>b__1(IEnumerator& partitionState, Int64 timeout, Boolean
      & replicationDelegateYieldedBeforeCompletion)
      --- End of stack trace from previous location ---
         at System.Threading.Tasks.Parallel.<>c__DisplayClass43_0`2.<PartitionerForEachWorker>b__1(IEnumerator& partitionState, Int64 timeout, Boolean
      & replicationDelegateYieldedBeforeCompletion)
         at System.Threading.Tasks.TaskReplicator.Replica.Execute()
         --- End of inner exception stack trace ---
         at System.Threading.Tasks.TaskReplicator.Run[TState](ReplicatableUserAction`1 action, ParallelOptions options, Boolean stopOnFirstFailure)
         at System.Threading.Tasks.Parallel.PartitionerForEachWorker[TSource,TLocal](Partitioner`1 source, ParallelOptions parallelOptions, Action`1 s
      impleBody, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Ac
      tion`1 localFinally)
      --- End of stack trace from previous location ---
         at System.Threading.Tasks.Parallel.PartitionerForEachWorker[TSource,TLocal](Partitioner`1 source, ParallelOptions parallelOptions, Action`1 s
      impleBody, Action`2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Ac
      tion`1 localFinally)
         at System.Threading.Tasks.Parallel.ForEachWorker[TSource,TLocal](IEnumerable`1 source, ParallelOptions parallelOptions, Action`1 body, Action
      `2 bodyWithState, Action`3 bodyWithStateAndIndex, Func`4 bodyWithStateAndLocal, Func`5 bodyWithEverything, Func`1 localInit, Action`1 localFinal
      ly)
         at System.Threading.Tasks.Parallel.ForEach[TSource](IEnumerable`1 source, Action`1 body)
         at Xamarin.Android.Tasks.GenerateJavaStubs.Run(Boolean useMarshalMethods) in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build
      .Tasks/Tasks/GenerateJavaStubs.cs:line 194
         at Xamarin.Android.Tasks.GenerateJavaStubs.RunTask() in /Users/runner/work/1/s/xamarin-android/src/Xamarin.Android.Build.Tasks/Tasks/Generate
      JavaStubs.cs:line 102
         at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in /Users/runner/work/1/s/xamarin-android/external/xamarin-android-tools/src/Microsoft
      .Android.Build.BaseTasks/AndroidTask.cs:line 25

It's possible for Mono.Cecil to return a null `Type` from `Resolve()`, so we can check to avoid the NRE.

Unfortunately, this causes the build to just fail on a different error:

    Xamarin.Android.Common.targets(1458,3): error XALNS7000:
      Java.Interop.Tools.Diagnostics.XamarinAndroidException: error XA4204: Unable to resolve interface type 'AndroidX.Navigation.NavController/IOnDestinationChangedListener'. Are you missing an assembly reference?
         at Java.Interop.Tools.Diagnostics.Diagnostic.Error(Int32 code, SequencePoint location, String message, Object[] args) in D:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.Diagnostics\Java.Interop.Tools.Diagnostics\Diagnostic.cs:line 154
         at Java.Interop.Tools.JavaCallableWrappers.Adapters.CecilImporter.CreateType(TypeDefinition type, IMetadataResolver resolver, CallableWrapperReaderOptions options, String outerType) in D:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.Adapters\CecilImporter.cs:line 106
         at Java.Interop.Tools.JavaCallableWrappers.Adapters.CecilImporter.CreateType(TypeDefinition type, IMetadataResolver resolver, CallableWrapperReaderOptions options) in D:\src\xamarin-android\external\Java.Interop\src\Java.Interop.Tools.JavaCallableWrappers\Java.Interop.Tools.JavaCallableWrappers.Adapters\CecilImporter.cs:line 19
         at MonoDroid.Tuner.FindJavaObjectsStep.ConvertToCallableWrappers(List`1 types) in D:\src\xamarin-android\src\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\FindJavaObjectsStep.cs:line 123
         at MonoDroid.Tuner.FindJavaObjectsStep.ScanAssembly(AssemblyDefinition assembly, StepContext context, String destinationJLOXml) in D:\src\xamarin-android\src\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\FindJavaObjectsStep.cs:line 63
         at MonoDroid.Tuner.FindJavaObjectsStep.ProcessAssembly(AssemblyDefinition assembly, StepContext context) in D:\src\xamarin-android\src\Xamarin.Android.Build.Tasks\Linker\MonoDroid.Tuner\FindJavaObjectsStep.cs:line 34
         at Xamarin.Android.Tasks.AssemblyPipeline.Run(AssemblyDefinition assembly, StepContext context) in D:\src\xamarin-android\src\Xamarin.Android.Build.Tasks\Utilities\AssemblyPipeline.cs:line 25
         at Xamarin.Android.Tasks.AssemblyModifierPipeline.RunPipeline(AssemblyPipeline pipeline, ITaskItem source, ITaskItem destination) in D:\src\xamarin-android\src\Xamarin.Android.Build.Tasks\Tasks\AssemblyModifierPipeline.cs:line 175
         at Xamarin.Android.Tasks.AssemblyModifierPipeline.RunTask() in D:\src\xamarin-android\src\Xamarin.Android.Build.Tasks\Tasks\AssemblyModifierPipeline.cs:line 123
         at Microsoft.Android.Build.Tasks.AndroidTask.Execute() in D:\src\xamarin-android\external\xamarin-android-tools\src\Microsoft.Android.Build.BaseTasks\AndroidTask.cs:line 25

Further investigation is needed to determine the root cause.

But we should take this as a first step.