### PR TITLE
[generator] Don't avoid blittable types for fields

### DIFF
--- a/tests/generator-Tests/expected.ji/NonStaticFields/NonStaticField.xml
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/NonStaticField.xml
@@ -9,6 +9,8 @@
 	  		final="false" name="SomeObject" static="false" visibility="public">
 	  		<field deprecated="not deprecated" final="true" name="Value" static="false" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false">
 	        </field>
+	    <field deprecated="not deprecated" final="false" name="BooleanValue" static="false" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
+	    <field deprecated="not deprecated" final="false" name="CharValue" static="false" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
 	    </class>
 	</package>
 </api>

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -36,6 +36,44 @@ namespace Xamarin.Test {
 			}
 		}
 
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='BooleanValue']"
+		public bool BooleanValue {
+			get {
+				const string __id = "BooleanValue.Z";
+
+				var __v = _members.InstanceFields.GetBooleanValue (__id, this);
+				return __v;
+			}
+			set {
+				const string __id = "BooleanValue.Z";
+
+				try {
+					_members.InstanceFields.SetValue (__id, this, value);
+				} finally {
+				}
+			}
+		}
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
+		public bool CharValue {
+			get {
+				const string __id = "CharValue.Z";
+
+				var __v = _members.InstanceFields.GetBooleanValue (__id, this);
+				return __v;
+			}
+			set {
+				const string __id = "CharValue.Z";
+
+				try {
+					_members.InstanceFields.SetValue (__id, this, value);
+				} finally {
+				}
+			}
+		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]

--- a/tests/generator-Tests/expected.ji/StaticFields/StaticField.xml
+++ b/tests/generator-Tests/expected.ji/StaticFields/StaticField.xml
@@ -11,6 +11,8 @@
 	        </field>
 	        <field deprecated="not deprecated" final="false" name="Value2" static="true" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false">
 	        </field>
+	    <field deprecated="not deprecated" final="false" name="BooleanValue" static="true" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
+	    <field deprecated="not deprecated" final="false" name="CharValue" static="true" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
 	    </class>
 	</package>
 </api>

--- a/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -47,6 +47,44 @@ namespace Xamarin.Test {
 			}
 		}
 
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='BooleanValue']"
+		public static bool BooleanValue {
+			get {
+				const string __id = "BooleanValue.Z";
+
+				var __v = _members.StaticFields.GetBooleanValue (__id);
+				return __v;
+			}
+			set {
+				const string __id = "BooleanValue.Z";
+
+				try {
+					_members.StaticFields.SetValue (__id, value);
+				} finally {
+				}
+			}
+		}
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
+		public static bool CharValue {
+			get {
+				const string __id = "CharValue.Z";
+
+				var __v = _members.StaticFields.GetBooleanValue (__id);
+				return __v;
+			}
+			set {
+				const string __id = "CharValue.Z";
+
+				try {
+					_members.StaticFields.SetValue (__id, value);
+				} finally {
+				}
+			}
+		}
+
 		static readonly JniPeerMembers _members = new JniPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		[global::System.Diagnostics.DebuggerBrowsable (global::System.Diagnostics.DebuggerBrowsableState.Never)]

--- a/tests/generator-Tests/expected.xaji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -38,6 +38,46 @@ namespace Xamarin.Test {
 			}
 		}
 
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='BooleanValue']"
+		[Register ("BooleanValue")]
+		public bool BooleanValue {
+			get {
+				const string __id = "BooleanValue.Z";
+
+				var __v = _members.InstanceFields.GetBooleanValue (__id, this);
+				return __v;
+			}
+			set {
+				const string __id = "BooleanValue.Z";
+
+				try {
+					_members.InstanceFields.SetValue (__id, this, value);
+				} finally {
+				}
+			}
+		}
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
+		[Register ("CharValue")]
+		public bool CharValue {
+			get {
+				const string __id = "CharValue.Z";
+
+				var __v = _members.InstanceFields.GetBooleanValue (__id, this);
+				return __v;
+			}
+			set {
+				const string __id = "CharValue.Z";
+
+				try {
+					_members.InstanceFields.SetValue (__id, this, value);
+				} finally {
+				}
+			}
+		}
+
 		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		internal static new IntPtr class_ref {

--- a/tests/generator-Tests/expected.xaji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -50,6 +50,46 @@ namespace Xamarin.Test {
 			}
 		}
 
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='BooleanValue']"
+		[Register ("BooleanValue")]
+		public static bool BooleanValue {
+			get {
+				const string __id = "BooleanValue.Z";
+
+				var __v = _members.StaticFields.GetBooleanValue (__id);
+				return __v;
+			}
+			set {
+				const string __id = "BooleanValue.Z";
+
+				try {
+					_members.StaticFields.SetValue (__id, value);
+				} finally {
+				}
+			}
+		}
+
+
+		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
+		[Register ("CharValue")]
+		public static bool CharValue {
+			get {
+				const string __id = "CharValue.Z";
+
+				var __v = _members.StaticFields.GetBooleanValue (__id);
+				return __v;
+			}
+			set {
+				const string __id = "CharValue.Z";
+
+				try {
+					_members.StaticFields.SetValue (__id, value);
+				} finally {
+				}
+			}
+		}
+
 		static readonly JniPeerMembers _members = new XAPeerMembers ("xamarin/test/SomeObject", typeof (SomeObject));
 
 		internal static new IntPtr class_ref {

--- a/tools/generator/SourceWriters/BoundFieldAsProperty.cs
+++ b/tools/generator/SourceWriters/BoundFieldAsProperty.cs
@@ -139,7 +139,10 @@ namespace generator.SourceWriters
 					writer.WriteLine (prep);
 				}
 
-				arg = field.SetParameters [0].ToNative (opt);
+				var param = field.SetParameters [0];
+				arg = param.Symbol.OnlyFormatOnMarshal
+					? opt.GetSafeIdentifier (param.Name)
+					: param.ToNative (opt);
 
 				if (opt.CodeGenerationTarget != CodeGenerationTarget.JavaInterop1 &&
 						field.SetParameters.HasCleanup &&


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10404

Context: 57f7bc849f36ec7c3159cc7729c7276b8dcd3ca4

Commit 57f7bc84 updated `generator` to "avoid non-blittable types" in native callback methods, for which there were two non-blittables:

  * System.Boolean, which should be marshaled as a System.SByte, and
  * System.Char, which should be marshaled as a System.UInt16.

The problem is that this hit a codepath which was *not* "for native callback methods": field bindings.

Consider [`android.widget.RelativeLayout.LayoutParams.alignWithParent`][0]:

	package android.widget;
	public /* partial */ class RelativeLayout {
	  public /* partial */ class LayoutParams {
	    public boolean alignWithParent;
	  }
	}

which is bound as [`RelativeLayout.LayoutParams.AlignWithParent`][1]:

	namespace Android.Widget;
	public partial class RelativeLayout {
	  public new partial class LayoutParams {
	    [Register]
	    public bool AlignWithParent {
	      get => _members.InstanceFields.GetBooleanValue ("alignWithParent.Z", this);
	      set {
	        _members.InstanceFields.SetValue("alignWithParent.Z", this, value ? (sbyte)1 : (sbyte)0);
	      }
	    }
	  }
	}

The problem is the property setter, which calls
`Java.Interop.JniPeerMembers.JniInstanceFields.SetValue(string, IJavaPeerable, sbyte)`. Before 57f7bc84, it would instead call
`Java.Interop.JniPeerMembers.JniInstanceFields.SetValue(string, IJavaPeerable, bool)`, but with 57f7bc84 there are now runtime crashes when boolean fields are accessed, starting in .NET 10 Preview 2.

The following code fragment:

	var p = new RelativeLayout.LayoutParams (1, 2) {
	  AlignWithParent = true,
	};

crashes with:

	F droid_boolfiel: java_vm_ext.cc:542] JNI DETECTED ERROR IN APPLICATION: attempt to access field boolean android.widget.RelativeLayout$LayoutParams.alignWithParent of type boolean with the wrong type byte: 0x709385d8
	F droid_boolfiel: java_vm_ext.cc:542]     in call to SetByteField
	F droid_boolfiel: java_vm_ext.cc:542]     from void crc6463d68d2626be2acb.MainActivity.n_onCreate(android.os.Bundle)

Fix this by updating `generator` so that `BoundFieldAsProperty.cs` uses the parameter as-is when `ISymbol.OnlyFormatOnMarshal`=true.

The binding for `RelativeLayout.LayoutParams.AlignWithParent` becomes:

	namespace Android.Widget;
	public partial class RelativeLayout {
	  public new partial class LayoutParams {
	    [Register]
	    public bool AlignWithParent {
	      get => _members.InstanceFields.GetBooleanValue ("alignWithParent.Z", this);
	      set {
	        _members.InstanceFields.SetValue("alignWithParent.Z", this, value);
	      }
	    }
	  }
	}

i.e. calling `JniPeerMembers.JniInstanceFields.SetValue(string, IJavaPeerable, bool)`.

[0]: https://developer.android.com/reference/android/widget/RelativeLayout.LayoutParams#alignWithParent
[1]: https://learn.microsoft.com/en-us/dotnet/api/android.widget.relativelayout.layoutparams.alignwithparent?view=net-android-34.0