### PR TITLE
[tests] *Actually* test `char` behavior

### DIFF
--- a/tests/generator-Tests/expected.ji/NonStaticFields/NonStaticField.xml
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/NonStaticField.xml
@@ -10,7 +10,7 @@
 	  		<field deprecated="not deprecated" final="true" name="Value" static="false" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false">
 	        </field>
 	    <field deprecated="not deprecated" final="false" name="BooleanValue" static="false" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
-	    <field deprecated="not deprecated" final="false" name="CharValue" static="false" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
+	    <field deprecated="not deprecated" final="false" name="CharValue" static="false" transient="false" type="char" type-generic-aware="int" visibility="public" volatile="false" />
 	    </class>
 	</package>
 </api>

--- a/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -57,15 +57,15 @@ namespace Xamarin.Test {
 
 
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
-		public bool CharValue {
+		public char CharValue {
 			get {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
-				var __v = _members.InstanceFields.GetBooleanValue (__id, this);
+				var __v = _members.InstanceFields.GetCharValue (__id, this);
 				return __v;
 			}
 			set {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
 				try {
 					_members.InstanceFields.SetValue (__id, this, value);

--- a/tests/generator-Tests/expected.ji/StaticFields/StaticField.xml
+++ b/tests/generator-Tests/expected.ji/StaticFields/StaticField.xml
@@ -12,7 +12,7 @@
 	        <field deprecated="not deprecated" final="false" name="Value2" static="true" transient="false" type="int" type-generic-aware="int" visibility="public" volatile="false">
 	        </field>
 	    <field deprecated="not deprecated" final="false" name="BooleanValue" static="true" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
-	    <field deprecated="not deprecated" final="false" name="CharValue" static="true" transient="false" type="boolean" type-generic-aware="int" visibility="public" volatile="false" />
+	    <field deprecated="not deprecated" final="false" name="CharValue" static="true" transient="false" type="char" type-generic-aware="int" visibility="public" volatile="false" />
 	    </class>
 	</package>
 </api>

--- a/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.ji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -68,15 +68,15 @@ namespace Xamarin.Test {
 
 
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
-		public static bool CharValue {
+		public static char CharValue {
 			get {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
-				var __v = _members.StaticFields.GetBooleanValue (__id);
+				var __v = _members.StaticFields.GetCharValue (__id);
 				return __v;
 			}
 			set {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
 				try {
 					_members.StaticFields.SetValue (__id, value);

--- a/tests/generator-Tests/expected.xaji/NonStaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/NonStaticFields/Xamarin.Test.SomeObject.cs
@@ -61,15 +61,15 @@ namespace Xamarin.Test {
 
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
 		[Register ("CharValue")]
-		public bool CharValue {
+		public char CharValue {
 			get {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
-				var __v = _members.InstanceFields.GetBooleanValue (__id, this);
+				var __v = _members.InstanceFields.GetCharValue (__id, this);
 				return __v;
 			}
 			set {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
 				try {
 					_members.InstanceFields.SetValue (__id, this, value);

--- a/tests/generator-Tests/expected.xaji/StaticFields/Xamarin.Test.SomeObject.cs
+++ b/tests/generator-Tests/expected.xaji/StaticFields/Xamarin.Test.SomeObject.cs
@@ -73,15 +73,15 @@ namespace Xamarin.Test {
 
 		// Metadata.xml XPath field reference: path="/api/package[@name='xamarin.test']/class[@name='SomeObject']/field[@name='CharValue']"
 		[Register ("CharValue")]
-		public static bool CharValue {
+		public static char CharValue {
 			get {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
-				var __v = _members.StaticFields.GetBooleanValue (__id);
+				var __v = _members.StaticFields.GetCharValue (__id);
 				return __v;
 			}
 			set {
-				const string __id = "CharValue.Z";
+				const string __id = "CharValue.C";
 
 				try {
 					_members.StaticFields.SetValue (__id, value);


### PR DESCRIPTION
Context: 90ac202e9a82bd13b9e160686bd14b5a5ddca0e9

Commit 90ac202e noted two non-blittable types, System.Boolean and System.Char, and attempted to update the unit tests to mention *both* of them, largely for completeness.

Unfortunately, the `CharValue` fields were still boolean, meaning System.Char output wasn't actually tested!

Update `tests/generator-Tests` so that `CharValue` is a `char`.