### PR TITLE
[build] remove old Xamarin.Android build settings

### DIFF
--- a/src/Java.Interop/Java.Interop.csproj
+++ b/src/Java.Interop/Java.Interop.csproj
@@ -4,7 +4,7 @@
     <XAConfigPath>..\..\bin\Build$(Configuration)\XAConfig.props</XAConfigPath>
   </PropertyGroup>
   <Import Condition="Exists ('$(XAConfigPath)')" Project="$(XAConfigPath)" />
-  <PropertyGroup Condition=" '$(XABuild)' != 'true' ">
+  <PropertyGroup>
     <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Java.Interop/Java.Interop.targets
+++ b/src/Java.Interop/Java.Interop.targets
@@ -32,22 +32,4 @@
     <Exec Command="&quot;$(JarPath)&quot; cf &quot;$(OutputPath)java-interop.jar&quot; -C &quot;$(IntermediateOutputPath)ji-classes&quot; ." />
   </Target>
   <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\Build$(Configuration)\Java.Interop.BootstrapTasks.dll" TaskName="Java.Interop.BootstrapTasks.ReplaceFileContents" />
-  <Target Name="BuildVersionInfo_g_cs"
-      Condition=" '$(GenerateAssemblyInfo)' == 'true' And '$(TargetFramework)' == 'monoandroid10' ">
-    <ItemGroup>
-      <Replacements Include="@VERSION@" Replacement="$(Version)"/>
-      <Replacements Include="@INFORMATIONALVERSION@" Replacement="$(InformationalVersion)"/>
-      <Replacements Include="@TITLE@" Replacement="$(AssemblyName)"/>
-      <Replacements Include="@PRODUCT@" Replacement="$(AssemblyName)"/>
-      <Replacements Include="@CONFIGURATION@" Replacement="$(Configuration)"/>
-    </ItemGroup>
-    <ReplaceFileContents
-        TemplateFile="$(MSBuildThisFileDirectory)..\..\build-tools\scripts\AssemblyInfo.g.cs.in"
-        OutputFile="$(IntermediateOutputPath)$(AssemblyName).AssemblyInfo.g.cs"
-        Replacements="@(Replacements)"
-    />
-    <ItemGroup>
-      <Compile Include="$(IntermediateOutputPath)$(AssemblyName).AssemblyInfo.g.cs"/>
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Reviewing `Java.Interop`'s build, I noticed some things we can delete now:

* Checking for `$(XABuild)`, as this is no longer used

* Checking for `$(TargetFramework)=monoandroid10`