### PR TITLE
[generator] Support major.minor API levels

### DIFF
--- a/src/Java.Interop.Tools.Generator/Enumification/ConstantEntry.cs
+++ b/src/Java.Interop.Tools.Generator/Enumification/ConstantEntry.cs
@@ -9,14 +9,14 @@ namespace Java.Interop.Tools.Generator.Enumification
 	public class ConstantEntry
 	{
 		public ConstantAction Action { get; set; }
-		public int ApiLevel { get; set; }
+		public AndroidSdkVersion ApiLevel { get; set; }
 		public string? JavaSignature { get; set; }
 		public string? Value { get; set; }
 		public string? EnumFullType { get; set; }
 		public string? EnumMember { get; set; }
 		public FieldAction FieldAction { get; set; }
 		public bool IsFlags { get; set; }
-		public int? DeprecatedSince { get; set; }
+		public AndroidSdkVersion? DeprecatedSince { get; set; }
 
 		public string EnumNamespace {
 			get {
@@ -100,7 +100,7 @@ namespace Java.Interop.Tools.Generator.Enumification
 		{
 			var entry = new ConstantEntry {
 				Action = ConstantAction.Enumify,
-				ApiLevel = parser.GetFieldAsInt (0),
+				ApiLevel = parser.GetFieldAsAndroidSdkVersion (0),
 				EnumFullType = parser.GetField (1),
 				EnumMember = parser.GetField (2),
 				JavaSignature = parser.GetField (3),
@@ -128,14 +128,14 @@ namespace Java.Interop.Tools.Generator.Enumification
 		{
 			var entry = new ConstantEntry {
 				Action = FromConstantActionString (parser.GetField (0)),
-				ApiLevel = parser.GetFieldAsInt (1),
+				ApiLevel = parser.GetFieldAsAndroidSdkVersion (1),
 				JavaSignature = parser.GetField (2),
 				Value = parser.GetField (3),
 				EnumFullType = parser.GetField (4),
 				EnumMember = parser.GetField (5),
 				FieldAction = FromFieldActionString (parser.GetField (6)),
 				IsFlags = parser.GetField (7).ToLowerInvariant () == "flags",
-				DeprecatedSince = parser.GetFieldAsNullableInt32 (8)
+				DeprecatedSince = parser.GetFieldAsNullableAndroidSdkVersion (8)
 			};
 
 			entry.NormalizeJavaSignature ();

--- a/src/Java.Interop.Tools.Generator/Enumification/MethodMapEntry.cs
+++ b/src/Java.Interop.Tools.Generator/Enumification/MethodMapEntry.cs
@@ -8,7 +8,7 @@ namespace Java.Interop.Tools.Generator.Enumification
 	public class MethodMapEntry
 	{
 		public MethodAction Action { get; set; }
-		public int ApiLevel { get; set; }
+		public AndroidSdkVersion ApiLevel { get; set; }
 		public string? JavaPackage { get; set; }
 		public string? JavaType { get; set; }
 		public string? JavaName { get; set; }
@@ -66,7 +66,7 @@ namespace Java.Interop.Tools.Generator.Enumification
 		{
 			var entry = new MethodMapEntry {
 				Action = MethodAction.Enumify,
-				ApiLevel = parser.GetFieldAsInt (0),
+				ApiLevel = parser.GetFieldAsAndroidSdkVersion (0),
 				JavaPackage = parser.GetField (1),
 				JavaType = parser.GetField (2),
 				JavaName = parser.GetField (3),
@@ -86,7 +86,7 @@ namespace Java.Interop.Tools.Generator.Enumification
 		{
 			var entry = new MethodMapEntry {
 				Action = FromMethodActionString (parser.GetField (0)),
-				ApiLevel = parser.GetFieldAsInt (1),
+				ApiLevel = parser.GetFieldAsAndroidSdkVersion (1),
 				JavaPackage = parser.GetField (2),
 				JavaType = parser.GetField (3),
 				JavaName = parser.GetField (4),

--- a/src/Java.Interop.Tools.Generator/Extensions/XmlExtensions.cs
+++ b/src/Java.Interop.Tools.Generator/Extensions/XmlExtensions.cs
@@ -3,6 +3,8 @@ using System.Globalization;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
+using Java.Interop.Tools.Generator;
+
 namespace Xamarin.Android.Tools
 {
 	static class XmlExtensions
@@ -13,11 +15,11 @@ namespace Xamarin.Android.Tools
 		public static string? XGetAttribute (this XPathNavigator nav, string name, string ns)
 			=> nav.GetAttribute (name, ns)?.Trim ();
 
-		public static int? XGetAttributeAsInt (this XElement element, string name)
+		public static AndroidSdkVersion? XGetAttributeAsAndroidSdkVersion (this XElement element, string name)
 		{
 			var value = element.XGetAttribute (name);
 
-			if (int.TryParse (value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
+			if (AndroidSdkVersion.TryParse (value, out var result))
 				return result;
 
 			return null;

--- a/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
+++ b/src/Java.Interop.Tools.Generator/Metadata/FixupXmlDocument.cs
@@ -28,7 +28,7 @@ namespace Java.Interop.Tools.Generator
 		public void Apply (ApiXmlDocument apiDocument, string apiLevelString, int productVersion)
 		{
 			// Defaulting to 0 here is fine
-			int.TryParse (apiLevelString, out var apiLevel);
+			AndroidSdkVersion.TryParse (apiLevelString, out var apiLevel);
 
 			var metadataChildren = FixupDocument.XPathSelectElements ("/metadata/*");
 
@@ -193,22 +193,22 @@ namespace Java.Interop.Tools.Generator
 			return list;
 		}
 
-		bool ShouldSkip (XElement node, int apiLevel, int productVersion)
+		bool ShouldSkip (XElement node, AndroidSdkVersion apiLevel, int productVersion)
 		{
 			if (apiLevel > 0) {
-				var since = node.XGetAttributeAsInt ("api-since");
-				var until = node.XGetAttributeAsInt ("api-until");
+				var since = node.XGetAttributeAsAndroidSdkVersion ("api-since");
+				var until = node.XGetAttributeAsAndroidSdkVersion ("api-until");
 
-				if (since is int since_int && since_int > apiLevel)
+				if (since is AndroidSdkVersion since_int && since_int > apiLevel)
 					return true;
-				else if (until is int until_int && until_int < apiLevel)
+				else if (until is AndroidSdkVersion until_int && until_int < apiLevel)
 					return true;
 			}
 
 			if (productVersion > 0) {
-				var product_version = node.XGetAttributeAsInt ("product-version");
+				var product_version = node.XGetAttributeAsAndroidSdkVersion ("product-version");
 
-				if (product_version is int version && version > productVersion)
+				if (product_version is AndroidSdkVersion version && version > productVersion)
 					return true;
 
 			}

--- a/src/Java.Interop.Tools.Generator/Utilities/AndroidSdkVersion.cs
+++ b/src/Java.Interop.Tools.Generator/Utilities/AndroidSdkVersion.cs
@@ -1,0 +1,126 @@
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Java.Interop.Tools.Generator;
+
+public struct AndroidSdkVersion : IComparable, IComparable<AndroidSdkVersion>, IEquatable<AndroidSdkVersion>
+{
+	public  int     ApiLevel        { get; private set; }
+	public  int     MinorRelease    { get; private set; }
+
+	public AndroidSdkVersion (int major, int minor = 0)
+	{
+		ApiLevel   = major;
+		MinorRelease   = minor;
+	}
+
+	int IComparable.CompareTo (object? value)
+	{
+		var other = value as AndroidSdkVersion?;
+		if (other == null) {
+			return 1;
+		}
+		return CompareTo (other.Value);
+	}
+
+	public int CompareTo (AndroidSdkVersion value)
+	{
+		int r = ApiLevel.CompareTo (value.ApiLevel);
+		if (r == 0) {
+			r = MinorRelease.CompareTo (value.MinorRelease);
+		}
+		return r;
+	}
+
+	public override int GetHashCode ()
+		=> ApiLevel ^ MinorRelease;
+
+	public override bool Equals (object? value)
+	{
+		var other = value as AndroidSdkVersion?;
+		if (other == null) {
+			return false;
+		}
+		return Equals (other.Value);
+	}
+
+	public bool Equals (AndroidSdkVersion value)
+	{
+		return value.ApiLevel == ApiLevel && value.MinorRelease == MinorRelease;
+	}
+
+	public override string ToString ()
+		=> MinorRelease == 0
+		? ApiLevel.ToString ()
+		: $"{ApiLevel}.{MinorRelease}";
+
+	//	public static implicit operator ApiLevel (int value)
+	//		=> new ApiLevel (value);
+
+	public static bool operator < (AndroidSdkVersion lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs) < 0;
+	public static bool operator <= (AndroidSdkVersion lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs) <= 0;
+	public static bool operator > (AndroidSdkVersion lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs) > 0;
+	public static bool operator >= (AndroidSdkVersion lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs) >= 0;
+	public static bool operator == (AndroidSdkVersion lhs, AndroidSdkVersion rhs)
+		=> lhs.Equals (rhs);
+	public static bool operator != (AndroidSdkVersion lhs, AndroidSdkVersion rhs)
+		=> !lhs.Equals (rhs);
+
+	public static bool operator < (AndroidSdkVersion lhs, int rhs)
+		=> lhs.ApiLevel.CompareTo (rhs) < 0;
+	public static bool operator <= (AndroidSdkVersion lhs, int rhs)
+		=> lhs.ApiLevel.CompareTo (rhs) <= 0;
+	public static bool operator > (AndroidSdkVersion lhs, int rhs)
+		=> lhs.ApiLevel.CompareTo (rhs) > 0;
+	public static bool operator >= (AndroidSdkVersion lhs, int rhs)
+		=> lhs.ApiLevel.CompareTo (rhs) >= 0;
+	public static bool operator == (AndroidSdkVersion lhs, int rhs)
+		=> lhs.ApiLevel.Equals (rhs);
+	public static bool operator != (AndroidSdkVersion lhs, int rhs)
+		=> !lhs.ApiLevel.Equals (rhs);
+
+	public static bool operator < (int lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs.ApiLevel) < 0;
+	public static bool operator <= (int lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs.ApiLevel) <= 0;
+	public static bool operator > (int lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs.ApiLevel) > 0;
+	public static bool operator >= (int lhs, AndroidSdkVersion rhs)
+		=> lhs.CompareTo (rhs.ApiLevel) >= 0;
+	public static bool operator == (int lhs, AndroidSdkVersion rhs)
+		=> lhs.Equals (rhs.ApiLevel);
+	public static bool operator != (int lhs, AndroidSdkVersion rhs)
+		=> !lhs.Equals (rhs.ApiLevel);
+
+	public static bool TryParse (string? value, out AndroidSdkVersion apiLevel)
+	{
+		if (value == null) {
+			apiLevel    = default;
+			return false;
+		}
+		if (Version.TryParse (value, out var v)) {
+			apiLevel    = new AndroidSdkVersion (v.Major, v.Minor);
+			return true;
+		}
+		if (int.TryParse (value, out var major)) {
+			apiLevel    = new AndroidSdkVersion (major);
+			return true;
+		}
+		apiLevel    = default;
+		return false;
+	}
+
+	public static AndroidSdkVersion Parse (string? value)
+	{
+		AndroidSdkVersion v;
+		if (TryParse (value, out v)) {
+			return v;
+		}
+		throw new NotSupportedException ($"Could not parse `{value}` as an ApiLevel.");
+	}
+}

--- a/src/Java.Interop.Tools.Generator/Utilities/CsvParser.cs
+++ b/src/Java.Interop.Tools.Generator/Utilities/CsvParser.cs
@@ -19,16 +19,16 @@ namespace Java.Interop.Tools.Generator
 			return fields [index].Trim ();
 		}
 
-		public int GetFieldAsInt (int index)
+		public AndroidSdkVersion GetFieldAsAndroidSdkVersion (int index)
 		{
-			return int.Parse (GetField (index));
+			return AndroidSdkVersion.Parse (GetField (index));
 		}
 
-		public int? GetFieldAsNullableInt32 (int index)
+		public AndroidSdkVersion? GetFieldAsNullableAndroidSdkVersion (int index)
 		{
 			var value = GetField (index);
 
-			if (int.TryParse (value, out var val))
+			if (AndroidSdkVersion.TryParse (value, out var val))
 				return val;
 
 			return default;

--- a/src/utils/XmlExtensions.cs
+++ b/src/utils/XmlExtensions.cs
@@ -5,6 +5,8 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
+using Java.Interop.Tools.Generator;
+
 namespace Xamarin.Android.Tools {
 
 	static class XmlExtensions {
@@ -21,14 +23,14 @@ namespace Xamarin.Android.Tools {
 			return attr != null ? attr.Trim () : null;
 		}
 
-		public static int? XGetAttributeAsIntOrNull (this XElement element, string name)
+		public static AndroidSdkVersion? XGetAttributeAsAndroidSdkVersionOrNull (this XElement element, string name)
 		{
 			var attr = element.Attribute (name);
 
 			if (attr?.Value is null)
 				return null;
 
-			if (int.TryParse (attr.Value, out var val))
+			if (AndroidSdkVersion.TryParse (attr.Value, out var val))
 				return val;
 
 			return null;

--- a/tests/Java.Interop.Tools.Generator-Tests/Enumification/ConstantEntryTests.cs
+++ b/tests/Java.Interop.Tools.Generator-Tests/Enumification/ConstantEntryTests.cs
@@ -13,7 +13,7 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv);
 
 			Assert.AreEqual (ConstantAction.Enumify, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", entry.EnumFullType);
@@ -29,7 +29,7 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv, true);
 
 			Assert.AreEqual (ConstantAction.Enumify, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", entry.EnumFullType);
@@ -45,7 +45,7 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv);
 
 			Assert.AreEqual (ConstantAction.Add, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual (string.Empty, entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", entry.EnumFullType);
@@ -61,7 +61,7 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv);
 
 			Assert.AreEqual (ConstantAction.Remove, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual (string.Empty, entry.EnumFullType);
@@ -77,7 +77,7 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv);
 
 			Assert.AreEqual (ConstantAction.Enumify, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", entry.EnumFullType);
@@ -94,7 +94,7 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv);
 
 			Assert.AreEqual (ConstantAction.Add, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual (string.Empty, entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", entry.EnumFullType);
@@ -111,14 +111,14 @@ namespace Java.Interop.Tools.Generator_Tests
 			var entry = ConstantEntry.FromString (csv);
 
 			Assert.AreEqual (ConstantAction.Remove, entry.Action);
-			Assert.AreEqual (10, entry.ApiLevel);
+			Assert.AreEqual (10, entry.ApiLevel.ApiLevel);
 			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", entry.JavaSignature);
 			Assert.AreEqual ("5", entry.Value);
 			Assert.AreEqual (string.Empty, entry.EnumFullType);
 			Assert.AreEqual (string.Empty, entry.EnumMember);
 			Assert.AreEqual (FieldAction.Remove, entry.FieldAction);
 			Assert.False (entry.IsFlags);
-			Assert.AreEqual (33, entry.DeprecatedSince.Value);
+			Assert.AreEqual (33, entry.DeprecatedSince?.ApiLevel ?? 0);
 		}
 	}
 }

--- a/tests/Java.Interop.Tools.Generator-Tests/Utilities/AndroidSdkVersionTests.cs
+++ b/tests/Java.Interop.Tools.Generator-Tests/Utilities/AndroidSdkVersionTests.cs
@@ -1,0 +1,63 @@
+using System;
+using Java.Interop.Tools.Generator;
+using NUnit.Framework;
+
+namespace Java.Interop.Tools.Generator_Tests;
+
+[TestFixture]
+public class AndroidSdkVersionTests
+{
+	[Test]
+	public void CompareTo()
+	{
+		var a   = new AndroidSdkVersion (1);
+		var b   = new AndroidSdkVersion (1);
+		var c   = new AndroidSdkVersion (36, 1);
+		Assert.AreEqual (0, a.CompareTo (b), $"1 == 1");
+		Assert.AreEqual (1, ((IComparable)a).CompareTo (null), $"1 < null");
+		Assert.IsTrue (a.CompareTo (c) < 0, $"1 < 36.1");
+		Assert.IsTrue (c.CompareTo (a) > 0, $"36.1 > 1");
+	}
+
+	[Test]
+	public void Operators ()
+	{
+		var a   = new AndroidSdkVersion (1);
+		var b   = new AndroidSdkVersion (1);
+		var c   = new AndroidSdkVersion (36, 1);
+
+		Assert.IsFalse (a < b);
+		Assert.IsTrue (a <= b);
+		Assert.IsTrue (a < c);
+		Assert.IsTrue (a <= c);
+
+		Assert.IsFalse (a > b);
+		Assert.IsTrue (a >= b);
+		Assert.IsTrue (c > a);
+		Assert.IsTrue (c >= a);
+	}
+
+	[Test]
+	public void TryParse ()
+	{
+		AndroidSdkVersion v;
+		Assert.IsFalse (AndroidSdkVersion.TryParse (null, out v));
+		Assert.IsFalse (AndroidSdkVersion.TryParse ("", out v));
+
+		Assert.IsTrue (AndroidSdkVersion.TryParse ("1", out v));
+		Assert.AreEqual (1, v.ApiLevel);
+		Assert.AreEqual (0, v.MinorRelease);
+
+		Assert.IsTrue (AndroidSdkVersion.TryParse ("36.1", out v));
+		Assert.AreEqual (36,    v.ApiLevel);
+		Assert.AreEqual (1,     v.MinorRelease);
+	}
+
+	[Test]
+	public new void ToString ()
+	{
+		Assert.AreEqual ("0",       new AndroidSdkVersion (0).ToString ());
+		Assert.AreEqual ("36",      new AndroidSdkVersion (36).ToString ());
+		Assert.AreEqual ("36.1",    new AndroidSdkVersion (36, 1).ToString ());
+	}
+}

--- a/tests/Java.Interop.Tools.Generator-Tests/Utilities/NamingConverterTests.cs
+++ b/tests/Java.Interop.Tools.Generator-Tests/Utilities/NamingConverterTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Java.Interop.Tools.Generator;
+using NUnit.Framework;
+
+namespace Java.Interop.Tools.Generator_Tests;
+
+[TestFixture]
+public class NamingConverterTests
+{
+	[Test]
+	public void ParseApiLevel_Exceptions ()
+	{
+		Assert.Throws<NotSupportedException> (() => NamingConverter.ParseApiLevel (@"..\..\bin\BuildDebug\api\api-CANARY.xml.in"));
+	}
+
+	[Test]
+	public void ParseApiLevel ()
+	{
+		AndroidSdkVersion v;
+
+		v = NamingConverter.ParseApiLevel (@"..\..\bin\BuildDebug\api\api-28.xml.in");
+		Assert.AreEqual (28,    v.ApiLevel);
+		Assert.AreEqual (0,     v.MinorRelease);
+
+		v = NamingConverter.ParseApiLevel (@"..\..\bin\BuildDebug\api\api-36.1.xml.in");
+		Assert.AreEqual (36,    v.ApiLevel);
+		Assert.AreEqual (1,     v.MinorRelease);
+
+		v = NamingConverter.ParseApiLevel (@"..\..\bin\BuildDebug\api\api-R.xml.in");
+		Assert.AreEqual (30,    v.ApiLevel);
+		Assert.AreEqual (0,     v.MinorRelease);
+	}
+}

--- a/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/CodeGeneratorTests.cs
@@ -794,12 +794,12 @@ namespace generatortests
 			// Ensure attribute was added to invoker class
 			var invoker_attribute = invoker.Attributes.OfType<ObsoletedOSPlatformAttr> ().Single ();
 			Assert.AreEqual ("This interface was deprecated in API-25", invoker_attribute.Message);
-			Assert.AreEqual (25, invoker_attribute.Version);
+			Assert.AreEqual (25, invoker_attribute.Version.ApiLevel);
 
 			// Ensure attribute was added to extensions class
 			var extensions_attribute = invoker.Attributes.OfType<ObsoletedOSPlatformAttr> ().Single ();
 			Assert.AreEqual ("This interface was deprecated in API-25", extensions_attribute.Message);
-			Assert.AreEqual (25, extensions_attribute.Version);
+			Assert.AreEqual (25, extensions_attribute.Version.ApiLevel);
 		}
 
 		[Test]
@@ -1223,7 +1223,7 @@ namespace generatortests
 			var gens = ParseApiDefinition (xml);
 
 			// Override method should match base method's 'deprecated-since'
-			Assert.AreEqual (11, gens.Single (g => g.Name == "MyClass").Methods.Single (m => m.Name == "DoStuff").DeprecatedSince);
+			Assert.AreEqual (11, gens.Single (g => g.Name == "MyClass").Methods.Single (m => m.Name == "DoStuff").DeprecatedSince?.ApiLevel ?? 0);
 		}
 
 		protected static IEnumerable<string> GetLinesThatStartWith (string source, string value)
@@ -1379,7 +1379,7 @@ namespace generatortests
 		{
 			// We do not write [SupportedOSPlatform] for JavaInterop, only XAJavaInterop
 			var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
-			klass.ApiAvailableSince = 30;
+			klass.ApiAvailableSince = new AndroidSdkVersion (30);
 
 			generator.Context.ContextTypes.Push (klass);
 			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
@@ -1395,7 +1395,7 @@ namespace generatortests
 			var klass = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar").SetConstant ("MY_VALUE");
 
-			field.ApiAvailableSince = 30;
+			field.ApiAvailableSince = new AndroidSdkVersion (30);
 
 			klass.Fields.Add (field);
 
@@ -1410,7 +1410,7 @@ namespace generatortests
 		public void UnsupportedOSPlatform ()
 		{
 			var klass = SupportTypeBuilder.CreateClass ("java.code.MyClass", options);
-			klass.ApiRemovedSince = 30;
+			klass.ApiRemovedSince = new AndroidSdkVersion (30);
 
 			generator.Context.ContextTypes.Push (klass);
 			generator.WriteType (klass, string.Empty, new GenerationInfo ("", "", "MyAssembly"));
@@ -1425,7 +1425,7 @@ namespace generatortests
 			var klass = new TestClass ("java.lang.Object", "com.mypackage.foo");
 			var field = new TestField ("java.lang.String", "bar").SetConstant ("MY_VALUE");
 
-			field.ApiRemovedSince = 30;
+			field.ApiRemovedSince = new AndroidSdkVersion (30);
 
 			klass.Fields.Add (field);
 

--- a/tests/generator-Tests/Unit-Tests/EnumGeneratorTests.cs
+++ b/tests/generator-Tests/Unit-Tests/EnumGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Java.Interop.Tools.Generator;
 using Java.Interop.Tools.Generator.Enumification;
 using MonoDroid.Generation;
 using NUnit.Framework;
@@ -150,7 +151,7 @@ namespace generatortests
 			options.UseObsoletedOSPlatformAttributes = true;
 
 			var enu = CreateEnum ();
-			enu.Value.Members.Single (m => m.EnumMember == "WithExcluded").DeprecatedSince = 33;
+			enu.Value.Members.Single (m => m.EnumMember == "WithExcluded").DeprecatedSince = new AndroidSdkVersion (33);
 
 			var gens = ParseApiDefinition (xml);
 
@@ -177,7 +178,7 @@ namespace generatortests
 			options.UseObsoletedOSPlatformAttributes = true;
 
 			var enu = CreateEnum ();
-			enu.Value.Members.Single (m => m.EnumMember == "WithExcluded").DeprecatedSince = -1;
+			enu.Value.Members.Single (m => m.EnumMember == "WithExcluded").DeprecatedSince = new AndroidSdkVersion (-1);
 
 			var gens = ParseApiDefinition (xml);
 
@@ -198,7 +199,7 @@ namespace generatortests
 		{
 			var enu = new EnumMappings.EnumDescription {
 				Members = new List<ConstantEntry> {
-					new ConstantEntry { EnumMember = "WithExcluded", Value = "1", JavaSignature = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE", ApiLevel = 30 },
+					new ConstantEntry { EnumMember = "WithExcluded", Value = "1", JavaSignature = "android/app/ActivityManager.RECENT_IGNORE_UNAVAILABLE", ApiLevel = new AndroidSdkVersion (30) },
 					new ConstantEntry { EnumMember = "IgnoreUnavailable", Value = "2", JavaSignature = "android/app/ActivityManager.RECENT_WITH_EXCLUDED" }
 				},
 				BitField = false,

--- a/tests/generator-Tests/Unit-Tests/EnumMappingsTests.cs
+++ b/tests/generator-Tests/Unit-Tests/EnumMappingsTests.cs
@@ -8,6 +8,8 @@ using System.Xml.Linq;
 using MonoDroid.Generation;
 using NUnit.Framework;
 
+using Java.Interop.Tools.Generator;
+
 namespace generatortests
 {
 	[TestFixture]
@@ -22,7 +24,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, ]", removes.Single ().ToString ());
 
@@ -42,7 +44,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, ]", removes.Single ().ToString ());
 
@@ -58,14 +60,14 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (0, removes.Count);
 
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (true, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("", enums.First().Value.Members.Single ().JavaSignature);
+			Assert.AreEqual ("", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -78,7 +80,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (true, enums.Single ().Value.BitField);
 		}
@@ -92,7 +94,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new [] { "Org.XmlPull.V1.XmlPullParserNode" }, 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new [] { "Org.XmlPull.V1.XmlPullParserNode" }, new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (true, enums.Single ().Value.BitField);
 		}
@@ -106,7 +108,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 5, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (5), removes);
 
 			Assert.AreEqual (0, removes.Count);
 			Assert.AreEqual (0, enums.Count);
@@ -121,14 +123,14 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, Org.XmlPull.V1.XmlPullParserNode]", removes.Single ().ToString ());
 
 			Assert.AreEqual ("Org.XmlPull.V1.XmlPullParserNode", enums.Single ().Key);
 			Assert.AreEqual (false, enums.Single ().Value.BitField);
 			Assert.AreEqual (false, enums.Single ().Value.FieldsRemoved);
-			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", enums.First().Value.Members.Single ().JavaSignature);
+			Assert.AreEqual ("I:org/xmlpull/v1/XmlPullParser.CDSECT", enums.First ().Value.Members.Single ().JavaSignature);
 			Assert.AreEqual ("[Cdsect, 5]", enums.First ().Value.Members.Single ().ToString ());
 		}
 
@@ -141,7 +143,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, ]", removes.Single ().ToString ());
 
@@ -157,7 +159,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (0, removes.Count);
 
@@ -176,7 +178,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, ]", removes.Single ().ToString ());
 
@@ -196,7 +198,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, ]", removes.Single ().ToString ());
 
@@ -212,7 +214,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (0, removes.Count);
 
@@ -232,7 +234,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (true, enums.Single ().Value.BitField);
 		}
@@ -246,7 +248,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new [] { "Org.XmlPull.V1.XmlPullParserNode" }, 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new [] { "Org.XmlPull.V1.XmlPullParserNode" }, new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual (true, enums.Single ().Value.BitField);
 		}
@@ -260,7 +262,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 5, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (5), removes);
 
 			Assert.AreEqual (0, removes.Count);
 			Assert.AreEqual (0, enums.Count);
@@ -275,7 +277,7 @@ namespace generatortests
 			var sr = new StringReader (csv);
 
 			var removes = new List<KeyValuePair<string, string>> ();
-			var enums = mappings.ParseFieldMappings (sr, new string [0], 30, removes);
+			var enums = mappings.ParseFieldMappings (sr, new string [0], new AndroidSdkVersion (30), removes);
 
 			Assert.AreEqual ("[I:org/xmlpull/v1/XmlPullParser.CDSECT, Org.XmlPull.V1.XmlPullParserNode]", removes.Single ().ToString ());
 

--- a/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
+++ b/tests/generator-Tests/Unit-Tests/XmlApiImporterTests.cs
@@ -28,7 +28,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='myclass' api-since='7' /></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.ApiAvailableSince);
+			Assert.AreEqual (7, klass.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -38,7 +38,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><class name='myclass' /></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.ApiAvailableSince);
+			Assert.AreEqual (7, klass.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -48,7 +48,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><class name='myclass' api-since='9' /></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (9, klass.ApiAvailableSince);
+			Assert.AreEqual (9, klass.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -57,7 +57,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='myclass' removed-since='7' /></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.ApiRemovedSince);
+			Assert.AreEqual (7, klass.ApiRemovedSince.ApiLevel);
 		}
 
 		[Test]
@@ -75,7 +75,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test'><constructor name='ctor' api-since='7' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Ctors [0].ApiAvailableSince);
+			Assert.AreEqual (7, klass.Ctors [0].ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -84,7 +84,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' api-since='7'><constructor name='ctor' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Ctors [0].ApiAvailableSince);
+			Assert.AreEqual (7, klass.Ctors [0].ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -93,7 +93,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' deprecated-since='7'><constructor name='ctor' deprecated-since='17' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Ctors [0].DeprecatedSince);
+			Assert.AreEqual (7, klass.Ctors [0].DeprecatedSince.Value.ApiLevel);
 		}
 
 		[Test]
@@ -143,17 +143,17 @@ namespace generatortests
 			var xml = XDocument.Parse ("<field name='$3' api-since='7' />");
 			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
-			Assert.AreEqual (7, field.ApiAvailableSince);
+			Assert.AreEqual (7, field.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
 		public void CreateField_CorrectApiVersionFromClass ()
 		{
-			var klass = new TestClass ("object", "MyNamespace.MyType") { ApiAvailableSince = 7 };
+			var klass = new TestClass ("object", "MyNamespace.MyType") { ApiAvailableSince = new AndroidSdkVersion (7) };
 			var xml = XDocument.Parse ("<field name='$3' />");
 			var field = XmlApiImporter.CreateField (klass, xml.Root);
 
-			Assert.AreEqual (7, field.ApiAvailableSince);
+			Assert.AreEqual (7, field.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -162,7 +162,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' deprecated-since='7'><field name='$3' deprecated-since='17' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Fields [0].DeprecatedSince);
+			Assert.AreEqual (7, klass.Fields [0].DeprecatedSince.Value.ApiLevel);
 		}
 
 		[Test]
@@ -180,7 +180,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><interface name='myclass' api-since='7' /></package>");
 			var iface = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("interface"), opt);
 
-			Assert.AreEqual (7, iface.ApiAvailableSince);
+			Assert.AreEqual (7, iface.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -190,7 +190,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><interface name='myclass' /></package>");
 			var iface = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("interface"), opt);
 
-			Assert.AreEqual (7, iface.ApiAvailableSince);
+			Assert.AreEqual (7, iface.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -200,7 +200,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test' api-since='7'><interface name='myclass' api-since='9' /></package>");
 			var iface = XmlApiImporter.CreateInterface (xml.Root, xml.Root.Element ("interface"), opt);
 
-			Assert.AreEqual (9, iface.ApiAvailableSince);
+			Assert.AreEqual (9, iface.ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -227,7 +227,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test'><method name='-3' api-since='7' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince);
+			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -236,7 +236,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' api-since='7'><method name='-3' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince);
+			Assert.AreEqual (7, klass.Methods [0].ApiAvailableSince.ApiLevel);
 		}
 
 		[Test]
@@ -245,7 +245,7 @@ namespace generatortests
 			var xml = XDocument.Parse ("<package name='com.example.test' jni-name='com/example/test'><class name='test' deprecated-since='7'><method name='-3' deprecated-since='17' /></class></package>");
 			var klass = XmlApiImporter.CreateClass (xml.Root, xml.Root.Element ("class"), opt);
 
-			Assert.AreEqual (7, klass.Methods [0].DeprecatedSince);
+			Assert.AreEqual (7, klass.Methods [0].DeprecatedSince.Value.ApiLevel);
 		}
 
 		[Test]

--- a/tools/generator/ApiVersionsProvider.cs
+++ b/tools/generator/ApiVersionsProvider.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Xml;
 using System.Linq;
+using Java.Interop.Tools.Generator;
 
 namespace Xamarin.AndroidTools.AnnotationSupport
 {
@@ -21,10 +22,10 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 			reader.MoveToContent (); // -> class
 			for (; reader.LocalName == "class"; reader.ReadToNextSibling ("class")) {
 
-				int tmpi;
+				AndroidSdkVersion tmpi;
 				var name = reader.GetAttribute ("name").Replace ('/', '.').Replace ('$', '.');
-				var since = int.Parse (reader.GetAttribute ("since"));
-				var deprecated = int.TryParse (reader.GetAttribute ("deprecated"), out tmpi) ? tmpi : 0;
+				var since = AndroidSdkVersion.Parse (reader.GetAttribute ("since"));
+				var deprecated = AndroidSdkVersion.TryParse (reader.GetAttribute ("deprecated"), out tmpi) ? tmpi : default;
 
 				ClassDefinition klass;
 				if (!Versions.TryGetValue (name, out klass)) {
@@ -41,15 +42,15 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 					var csince = reader.GetAttribute ("since");
 					if (csince == null)
 						continue;
-					var cdeprecated = int.TryParse (reader.GetAttribute ("deprecated"), out tmpi) ? tmpi : 0;
+					var cdeprecated = AndroidSdkVersion.TryParse (reader.GetAttribute ("deprecated"), out tmpi) ? tmpi : default;
 
 					var cname = reader.GetAttribute ("name");
 					switch (reader.LocalName) {
 					case "field":
-						klass.Fields.Add (new Definition { Name = cname, Since = int.Parse (csince), Deprecated = cdeprecated });
+						klass.Fields.Add (new Definition { Name = cname, Since = AndroidSdkVersion.Parse (csince), Deprecated = cdeprecated });
 						break;
 					case "method":
-						klass.Methods.Add (new Definition { Name = cname, Since = int.Parse (csince), Deprecated = cdeprecated });
+						klass.Methods.Add (new Definition { Name = cname, Since = AndroidSdkVersion.Parse (csince), Deprecated = cdeprecated });
 						break;
 					}
 				}
@@ -59,8 +60,8 @@ namespace Xamarin.AndroidTools.AnnotationSupport
 		public class Definition
 		{
 			public string Name; // it is name + JNI signature for methods.
-			public int Since;
-			public int Deprecated;
+			public AndroidSdkVersion Since;
+			public AndroidSdkVersion Deprecated;
 
 			string method;
 #if !GENERATOR

--- a/tools/generator/ApiVersionsSupport.cs
+++ b/tools/generator/ApiVersionsSupport.cs
@@ -3,13 +3,15 @@ using System.Collections.Generic;
 using Xamarin.AndroidTools.AnnotationSupport;
 using System.Linq;
 
+using Java.Interop.Tools.Generator;
+
 namespace MonoDroid.Generation
 {
 	static class IApiAvailabilityExtensions
 	{
 		public static string AdditionalAttributeString (this ApiVersionsSupport.IApiAvailability a)
 		{
-			return a.ApiAvailableSince == 0 ? null : ", ApiSince = " + a.ApiAvailableSince;
+			return a.ApiAvailableSince.ApiLevel == 0 ? null : ", ApiSince = " + a.ApiAvailableSince.ApiLevel;
 		}
 	}
 
@@ -17,8 +19,8 @@ namespace MonoDroid.Generation
 	{
 		public interface IApiAvailability
 		{
-			int ApiAvailableSince { get; set; }
-			int ApiRemovedSince { get; set; }
+			AndroidSdkVersion ApiAvailableSince { get; set; }
+			AndroidSdkVersion ApiRemovedSince { get; set; }
 		}
 
 		static IEnumerable<GenBase> FlattenGens (IEnumerable<GenBase> gens)

--- a/tools/generator/GenerationInfo.cs
+++ b/tools/generator/GenerationInfo.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
-
+using Java.Interop.Tools.Generator;
 using Xamarin.Android.Binder;
 
 namespace MonoDroid.Generation {
@@ -71,13 +71,22 @@ namespace MonoDroid.Generation {
 		{
 			if (options.ApiLevel == null)
 				return null;
-			int level;
-			if (!int.TryParse (options.ApiLevel, out level))
+			AndroidSdkVersion level;
+			if (!AndroidSdkVersion.TryParse (options.ApiLevel, out level))
 				return null;
 			var defines = new StringBuilder ()
 				.Append ("$(DefineConstants);ANDROID_1");
-			for (int i = 2; i <= level; ++i) {
+			for (int i = 2; i <= level.ApiLevel; ++i) {
 				defines.AppendFormat (";ANDROID_{0}", i.ToString ());
+			}
+			// ASSUME one minor release per major release starting with API-36.1
+			for (int i = 36; i < level.ApiLevel; ++i) {
+				defines.Append ($";ANDROID_{i}_1");
+			}
+			if (level.MinorRelease != 0) {
+				for (int i = 1; i < level.MinorRelease + 1; ++i) {
+					defines.Append ($";ANDROID_{level.ApiLevel}_{i}");
+				}
 			}
 			return new XElement (
 				msbuild + "PropertyGroup",

--- a/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Importers/XmlApiImporter.cs
@@ -162,7 +162,7 @@ namespace MonoDroid.Generation
 				ApiRemovedSince = declaringType.ApiRemovedSince,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
-				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
+				DeprecatedSince = elem.XGetAttributeAsAndroidSdkVersionOrNull ("deprecated-since"),
 				GenericArguments = elem.GenericArguments (),
 				Name = elem.XGetAttribute ("name"),
 				Visibility = elem.Visibility ()
@@ -199,7 +199,7 @@ namespace MonoDroid.Generation
 			ctor.Name = EnsureValidIdentifer (ctor.Name);
 
 			// If declaring type was deprecated earlier than member, use the type's deprecated-since
-			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince.Value < ctor.DeprecatedSince.GetValueOrDefault (0))
+			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince < ctor.DeprecatedSince.GetValueOrDefault (default))
 				ctor.DeprecatedSince = declaringType.DeprecatedSince;
 
 			FillApiSince (ctor, elem);
@@ -214,7 +214,7 @@ namespace MonoDroid.Generation
 				ApiAvailableSince = declaringType.ApiAvailableSince,
 				ApiRemovedSince = declaringType.ApiRemovedSince,
 				DeprecatedComment = elem.XGetAttribute ("deprecated"),
-				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
+				DeprecatedSince = elem.XGetAttributeAsAndroidSdkVersionOrNull ("deprecated-since"),
 				IsAcw = true,
 				IsDeprecated = elem.XGetAttribute ("deprecated") != "not deprecated",
 				IsDeprecatedError = elem.XGetAttribute ("deprecated-error") == "true",
@@ -244,7 +244,7 @@ namespace MonoDroid.Generation
 			}
 
 			// If declaring type was deprecated earlier than member, use the type's deprecated-since
-			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince.Value < field.DeprecatedSince.GetValueOrDefault (0))
+			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince < field.DeprecatedSince.GetValueOrDefault (default))
 				field.DeprecatedSince = declaringType.DeprecatedSince;
 
 			FillApiSince (field, elem);
@@ -257,7 +257,7 @@ namespace MonoDroid.Generation
 		{
 			var support = new GenBaseSupport {
 				AnnotatedVisibility = elem.XGetAttribute ("annotated-visibility"),
-				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
+				DeprecatedSince = elem.XGetAttributeAsAndroidSdkVersionOrNull ("deprecated-since"),
 				IsAcw = true,
 				IsDeprecated = elem.XGetAttribute ("deprecated") != "not deprecated",
 				IsGeneratable = true,
@@ -375,7 +375,7 @@ namespace MonoDroid.Generation
 				ArgsType = elem.Attribute ("argsType")?.Value,
 				CustomAttributes = elem.XGetAttribute ("customAttributes"),
 				Deprecated = elem.Deprecated (),
-				DeprecatedSince = elem.XGetAttributeAsIntOrNull ("deprecated-since"),
+				DeprecatedSince = elem.XGetAttributeAsAndroidSdkVersionOrNull ("deprecated-since"),
 				ExplicitInterface = elem.XGetAttribute ("explicitInterface"),
 				EventName = elem.Attribute ("eventName")?.Value,
 				GenerateAsyncWrapper = elem.Attribute ("generateAsyncWrapper") != null,
@@ -428,7 +428,7 @@ namespace MonoDroid.Generation
 			method.FillReturnType ();
 
 			// If declaring type was deprecated earlier than member, use the type's deprecated-since
-			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince.Value < method.DeprecatedSince.GetValueOrDefault (0))
+			if (declaringType.DeprecatedSince.HasValue && declaringType.DeprecatedSince < method.DeprecatedSince.GetValueOrDefault (default))
 				method.DeprecatedSince = declaringType.DeprecatedSince;
 
 			FillApiSince (method, elem);
@@ -519,9 +519,9 @@ namespace MonoDroid.Generation
 		static void FillApiSince (ApiVersionsSupport.IApiAvailability model, params XElement[] elems)
 		{
 			foreach (var elem in elems) {
-				if (int.TryParse (elem.XGetAttribute ("api-since"), out var result))
+				if (AndroidSdkVersion.TryParse (elem.XGetAttribute ("api-since"), out var result))
 					model.ApiAvailableSince = result;
-				if (int.TryParse (elem.XGetAttribute ("removed-since"), out var removed))
+				if (AndroidSdkVersion.TryParse (elem.XGetAttribute ("removed-since"), out var removed))
 					model.ApiRemovedSince = removed;
 			}
 		}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/Field.cs
@@ -8,10 +8,10 @@ namespace MonoDroid.Generation
 	{
 		public string AnnotatedVisibility { get; set; }
 		public string Annotation { get; set; }
-		public int ApiAvailableSince { get; set; }
-		public int ApiRemovedSince { get; set; }
+		public AndroidSdkVersion ApiAvailableSince { get; set; }
+		public AndroidSdkVersion ApiRemovedSince { get; set; }
 		public string DeprecatedComment { get; set; }
-		public int? DeprecatedSince { get; set; }
+		public AndroidSdkVersion? DeprecatedSince { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
 		public bool IsDeprecatedError { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBase.cs
@@ -186,9 +186,9 @@ namespace MonoDroid.Generation
 			? $"{FullName.Replace ('.', '/')}"
 			: $"{Namespace}." + $"{FullName.Substring (Namespace.Length + 1).Replace ('.', '/')}";
 
-		public int ApiAvailableSince { get; set; }
+		public AndroidSdkVersion ApiAvailableSince { get; set; }
 
-		public int ApiRemovedSince { get; set; }
+		public AndroidSdkVersion ApiRemovedSince { get; set; }
 
 		public virtual ClassGen BaseGen => null;
 
@@ -255,7 +255,7 @@ namespace MonoDroid.Generation
 
 		public string DeprecatedComment => support.DeprecatedComment;
 
-		public int? DeprecatedSince => support.DeprecatedSince;
+		public AndroidSdkVersion? DeprecatedSince => support.DeprecatedSince;
 
 		IEnumerable<GenBase> Descendants (IList<GenBase> gens)
 		{
@@ -319,14 +319,14 @@ namespace MonoDroid.Generation
 								m.Deprecated = bm.Deprecated;
 
 							// Fix issue when base method was deprecated before the overriding method, set both both to base method value
-							if (bm.DeprecatedSince.GetValueOrDefault (0) < m.DeprecatedSince.GetValueOrDefault (0))
+							if (bm.DeprecatedSince.GetValueOrDefault (default) < m.DeprecatedSince.GetValueOrDefault (default))
 								m.DeprecatedSince = bm.DeprecatedSince;
 						}
 
 						// If a "removed" method overrides a "not removed" method, the method was
 						// likely moved to a base class, so don't mark it as removed.
 						if (m.ApiRemovedSince > 0 && bm.ApiRemovedSince == 0)
-							m.ApiRemovedSince = 0;
+							m.ApiRemovedSince = default;
 
 						break;
 					}

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/GenBaseSupport.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 
+using Java.Interop.Tools.Generator;
+
 namespace MonoDroid.Generation
 {
 	public class GenBaseSupport
@@ -11,7 +13,7 @@ namespace MonoDroid.Generation
 		public bool IsAcw { get; set; }
 		public bool IsDeprecated { get; set; }
 		public string DeprecatedComment { get; set; }
-		public int? DeprecatedSince { get; set; }
+		public AndroidSdkVersion? DeprecatedSince { get; set; }
 		public bool IsGeneratable { get; set; }
 		public bool IsGeneric { get; set; }
 		public bool IsObfuscated { get; set; }

--- a/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.ObjectModel/MethodBase.cs
@@ -15,12 +15,12 @@ namespace MonoDroid.Generation
 
 		public string AnnotatedVisibility { get; set; }
 		public string Annotation { get; internal set; }
-		public int ApiAvailableSince { get; set; }
-		public int ApiRemovedSince { get; set; }
+		public AndroidSdkVersion ApiAvailableSince { get; set; }
+		public AndroidSdkVersion ApiRemovedSince { get; set; }
 		public string AssemblyName { get; set; }
 		public GenBase DeclaringType { get; }
 		public string Deprecated { get; set; }
-		public int? DeprecatedSince { get; set; }
+		public AndroidSdkVersion? DeprecatedSince { get; set; }
 		public GenericParameterDefinitionList GenericArguments { get; set; }
 		public bool IsAcw { get; set; }
 		public bool IsValid { get; private set; }

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMap.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMap.cs
@@ -14,14 +14,14 @@ namespace MonoDroid.Generation
 		private string output_dir;
 		private string output_metadata;
 		private List<KeyValuePair<string, string>> remove_nodes;
-		private int version;
+		private AndroidSdkVersion version;
 		private bool fix_constants_instead_of_removing;
 
 		public EnumMappings (string outputDir, string outputMetadata, string version, bool fixConstantsInsteadOfRemove)
 		{
 			output_dir = outputDir;
 			output_metadata = outputMetadata;
-			this.version = version == null ? 0 : int.Parse (version);
+			this.version = version == null ? default : AndroidSdkVersion.Parse (version);
 			fix_constants_instead_of_removing = fixConstantsInsteadOfRemove;
 		}
 

--- a/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
+++ b/tools/generator/Java.Interop.Tools.Generator.Transformation/EnumMappings.cs
@@ -25,12 +25,12 @@ namespace MonoDroid.Generation {
 			public bool FieldsRemoved;
 		}
 
-		internal Dictionary<string, EnumDescription> ParseXmlFieldMappings (string csv, int filter_version, IList<KeyValuePair<string, string>> remove_nodes)
+		internal Dictionary<string, EnumDescription> ParseXmlFieldMappings (string csv, AndroidSdkVersion filter_version, IList<KeyValuePair<string, string>> remove_nodes)
 		{
 			return ParseFieldMappings (FieldXmlToCsv (csv), null, filter_version, remove_nodes);
 		}
 
-		internal Dictionary<string, EnumDescription> ParseFieldMappings (string csv, string flagsFile, int filter_version, IList<KeyValuePair<string, string>> remove_nodes)
+		internal Dictionary<string, EnumDescription> ParseFieldMappings (string csv, string flagsFile, AndroidSdkVersion filter_version, IList<KeyValuePair<string, string>> remove_nodes)
 		{
 			if (csv == null)
 				return new Dictionary<string, EnumDescription> ();
@@ -42,7 +42,7 @@ namespace MonoDroid.Generation {
 		// value: Dictionary:
 		//	key: enum element name
 		//	value: enum element value
-		internal Dictionary<string, EnumDescription> ParseFieldMappings (TextReader source, string [] enumFlags, int filter_version, IList<KeyValuePair<string, string>> remove_nodes)
+		internal Dictionary<string, EnumDescription> ParseFieldMappings (TextReader source, string [] enumFlags, AndroidSdkVersion filter_version, IList<KeyValuePair<string, string>> remove_nodes)
 		{
 			var enums = new Dictionary<string, EnumDescription> ();
 
@@ -184,12 +184,12 @@ namespace MonoDroid.Generation {
 			return new StringReader (sw.ToString ());
 		}
 
-		internal List<ApiTransform> ParseXmlMethodMappings (string file, int filter_version)
+		internal List<ApiTransform> ParseXmlMethodMappings (string file, AndroidSdkVersion filter_version)
 		{
 			return ParseMethodMappings (MethodXmlToCsv (file), filter_version);
 		}
 
-		internal List<ApiTransform> ParseMethodMappings (string file, int filter_version)
+		internal List<ApiTransform> ParseMethodMappings (string file, AndroidSdkVersion filter_version)
 		{
 			if (file == null)
 				return new List<ApiTransform> ();
@@ -197,7 +197,7 @@ namespace MonoDroid.Generation {
 				return ParseMethodMappings (sr, filter_version);
 		}
 
-		internal List<ApiTransform> ParseMethodMappings (TextReader source, int filter_version)
+		internal List<ApiTransform> ParseMethodMappings (TextReader source, AndroidSdkVersion filter_version)
 		{
 			var list = new List<ApiTransform> ();
 			if (source == null)
@@ -213,8 +213,10 @@ namespace MonoDroid.Generation {
 				if (s.Length == 0 || s.StartsWith ("//", StringComparison.Ordinal))
 					continue;
 				var items = s.Split (',');
-				int ver;
-				if (filter_version > 0 && int.TryParse (items [0], out ver) && filter_version < ver)
+				AndroidSdkVersion ver;
+				if (filter_version > 0 &&
+						AndroidSdkVersion.TryParse (items [0], out ver) &&
+						filter_version < ver)
 					continue;
 				try {
 					list.Add (new ApiTransform (preserveTypeMode, items));

--- a/tools/generator/SourceWriters/Attributes/ObsoletedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/ObsoletedOSPlatformAttr.cs
@@ -1,14 +1,16 @@
 using System;
 using Xamarin.SourceWriter;
 
+using Java.Interop.Tools.Generator;
+
 namespace generator.SourceWriters
 {
 	public class ObsoletedOSPlatformAttr : AttributeWriter
 	{
 		public string Message { get; set; }
-		public int Version { get; }
+		public AndroidSdkVersion Version { get; }
 
-		public ObsoletedOSPlatformAttr (string message, int version)
+		public ObsoletedOSPlatformAttr (string message, AndroidSdkVersion version)
 		{
 			Message = message;
 			Version = version;
@@ -16,10 +18,14 @@ namespace generator.SourceWriters
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
+			var apiLevel = Version.MinorRelease == 0
+				? $"{Version.ApiLevel}.0"
+				: Version.ToString ();
+
 			if (Message.HasValue ())
-				writer.WriteLine ($"[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android{Version}.0\", @\"{Message.Replace ("\"", "\"\"")}\")]");
+				writer.WriteLine ($"[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android{apiLevel}\", @\"{Message.Replace ("\"", "\"\"")}\")]");
 			else
-				writer.WriteLine ($"[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android{Version}.0\")]");
+				writer.WriteLine ($"[global::System.Runtime.Versioning.ObsoletedOSPlatform (\"android{apiLevel}\")]");
 		}
 	}
 }

--- a/tools/generator/SourceWriters/Attributes/SupportedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/SupportedOSPlatformAttr.cs
@@ -5,17 +5,22 @@ using System.Text;
 using System.Threading.Tasks;
 using Xamarin.SourceWriter;
 
+using Java.Interop.Tools.Generator;
+
 namespace generator.SourceWriters
 {
 	public class SupportedOSPlatformAttr : AttributeWriter
 	{
-		public int Version { get; }
+		public AndroidSdkVersion Version { get; }
 
-		public SupportedOSPlatformAttr (int version) => Version = version;
+		public SupportedOSPlatformAttr (AndroidSdkVersion version) => Version = version;
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			writer.WriteLine ($"[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android{Version}.0\")]");
+			var apiLevel = Version.MinorRelease == 0
+				? $"{Version.ApiLevel}.0"
+				: Version.ToString ();
+			writer.WriteLine ($"[global::System.Runtime.Versioning.SupportedOSPlatformAttribute (\"android{apiLevel}\")]");
 		}
 	}
 }

--- a/tools/generator/SourceWriters/Attributes/UnsupportedOSPlatformAttr.cs
+++ b/tools/generator/SourceWriters/Attributes/UnsupportedOSPlatformAttr.cs
@@ -5,17 +5,22 @@ using System.Text;
 using System.Threading.Tasks;
 using Xamarin.SourceWriter;
 
+using Java.Interop.Tools.Generator;
+
 namespace generator.SourceWriters
 {
 	public class UnsupportedOSPlatformAttr : AttributeWriter
 	{
-		public int Version { get; }
+		public AndroidSdkVersion Version { get; }
 
-		public UnsupportedOSPlatformAttr (int version) => Version = version;
+		public UnsupportedOSPlatformAttr (AndroidSdkVersion version) => Version = version;
 
 		public override void WriteAttribute (CodeWriter writer)
 		{
-			writer.WriteLine ($"[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android{Version}.0\")]");
+			var apiLevel = Version.MinorRelease == 0
+				? $"{Version.ApiLevel}.0"
+				: Version.ToString ();
+			writer.WriteLine ($"[global::System.Runtime.Versioning.UnsupportedOSPlatformAttribute (\"android{apiLevel}\")]");
 		}
 	}
 }

--- a/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
+++ b/tools/generator/SourceWriters/Extensions/SourceWriterExtensions.cs
@@ -313,7 +313,7 @@ namespace generator.SourceWriters
 			AddUnsupportedOSPlatform (attributes, member.ApiRemovedSince, opt);
 		}
 
-		public static void AddSupportedOSPlatform (List<AttributeWriter> attributes, int since, CodeGenerationOptions opt)
+		public static void AddSupportedOSPlatform (List<AttributeWriter> attributes, AndroidSdkVersion since, CodeGenerationOptions opt)
 		{
 			// There's no sense in writing say 'android15' because we do not support older APIs,
 			// so those APIs will be available in all of our versions.
@@ -321,14 +321,14 @@ namespace generator.SourceWriters
 				attributes.Add (new SupportedOSPlatformAttr (since));
 		}
 
-		public static void AddUnsupportedOSPlatform (List<AttributeWriter> attributes, int since, CodeGenerationOptions opt)
+		public static void AddUnsupportedOSPlatform (List<AttributeWriter> attributes, AndroidSdkVersion since, CodeGenerationOptions opt)
 		{
 			// Here it makes sense to still write 'android15' because it will be missing in later versions like `android35`.
 			if (since > 0 && opt.CodeGenerationTarget == CodeGenerationTarget.XAJavaInterop1)
 				attributes.Add (new UnsupportedOSPlatformAttr (since));
 		}
 
-		public static void AddObsolete (List<AttributeWriter> attributes, string message, CodeGenerationOptions opt, bool forceDeprecate = false, bool isError = false, int? deprecatedSince = null)
+		public static void AddObsolete (List<AttributeWriter> attributes, string message, CodeGenerationOptions opt, bool forceDeprecate = false, bool isError = false, AndroidSdkVersion? deprecatedSince = null)
 		{
 			// Bail if we're not obsolete
 			if ((!forceDeprecate && !message.HasValue ()) || message == "not deprecated")
@@ -342,13 +342,13 @@ namespace generator.SourceWriters
 		}
 
 		// Returns true if attribute was applied
-		static bool AddObsoletedOSPlatformAttribute (List<AttributeWriter> attributes, string message, int? deprecatedSince, CodeGenerationOptions opt)
+		static bool AddObsoletedOSPlatformAttribute (List<AttributeWriter> attributes, string message, AndroidSdkVersion? deprecatedSince, CodeGenerationOptions opt)
 		{
 			if (!opt.UseObsoletedOSPlatformAttributes)
 				return false;
 
 			// If it was obsoleted in a version earlier than we support (like 15), use a regular [Obsolete] instead
-			if (!deprecatedSince.HasValue || deprecatedSince <= MINIMUM_API_LEVEL)
+			if (!deprecatedSince.HasValue || deprecatedSince.Value <= MINIMUM_API_LEVEL)
 				return false;
 
 			// This is the default Android message, but it isn't useful so remove it

--- a/tools/generator/Utilities/CsvParser.cs
+++ b/tools/generator/Utilities/CsvParser.cs
@@ -22,10 +22,5 @@ namespace MonoDroid.Generation
 
 			return fields [index].Trim ();
 		}
-
-		public int GetFieldAsInt (int index)
-		{
-			return int.Parse (GetField (index));
-		}
 	}
 }


### PR DESCRIPTION
[generator] Support major.minor API levels

Context: https://github.com/dotnet/android/pull/10438
Context: https://github.com/dotnet/android/pull/10438#issuecomment-3246300570

Android 16 Quarterly Platform Release 2 (QPR2) (API-CANARY) Beta 1
has been released.  What makes API_CANARY unique in the history of
Android is that it is a "minor" SDK version:

  * [`<uses-sdk/>`][3]:

    > It's not possible to specify that an app either targets or requires a minor SDK version.

  * [Using new APIs with major and minor releases][4]:

    > The new [`SDK_INT_FULL`][5] constant can be used for API checks…
    >
    >     if (SDK_INT_FULL >= VERSION_CODES_FULL.[MAJOR or MINOR RELEASE]) {
    >       // Use APIs introduced in a major or minor release
    >     }
    >
    > You can also use the [`Build.getMinorSdkVersion()`][6] method to
    > get just the minor SDK version:
    >
    >     minorSdkVersion = Build.getMinorSdkVersion(Build.VERSION_CODES_FULL.BAKLAVA);

This is ***not*** "API-37".  This is "API-36.1"

This impacts *everything*:

  * `[SupportedOSPlatform]` should include the minor SDK value
  * `[UnsupportedOSPlatform]` should also include the minor SDK value.
  * `generator --api-level=API-LEVEL` should include the minor value
  * …

Add a new `Java.Interop.Tools.Generator.ApiLevel` type which holds
the Android SDK version, both major and minor values.  This is a
value type which works like `System.Int32`/`System.Version`.

Replace all instances of `int ApiLevel` (and equivalent) with
`ApiLevel ApiLevel` (and equivalent).

Update `[SupportedOSPlatform]`, `[UnsupportedOSPlatform]`, and
`[ObsoletedOSPlatform]` attribute output to include the full SDK value.

[3]: https://developer.android.com/guide/topics/manifest/uses-sdk-element
[4]: https://developer.android.com/about/versions/16/features#using-new
[5]: https://developer.android.com/reference/android/os/Build.VERSION#SDK_INT_FULL
[6]: https://developer.android.com/reference/android/os/Build#getMinorSdkVersion(int)
