### PR TITLE
[Java.Interop.Tools.Generator] Improve ExtractApiLevel() resiliency

### DIFF
--- a/src/Java.Interop.Tools.Generator/Utilities/NamingConverter.cs
+++ b/src/Java.Interop.Tools.Generator/Utilities/NamingConverter.cs
@@ -27,11 +27,14 @@ namespace Java.Interop.Tools.Generator
 			if (!value.HasValue ())
 				return null;
 
-			var hyphen  = value.IndexOf ('-');
-			if (hyphen < 0 || (hyphen+1) >= value.Length)
-				return null;
+			const string ApiFilenamePrefix = "api-";
 
-			int end     = hyphen + 1;
+			var hyphen  = value.LastIndexOf (ApiFilenamePrefix);
+			if (hyphen < 0 || checked (hyphen + 1 + ApiFilenamePrefix.Length) >= value.Length)
+				return null;
+			hyphen      += ApiFilenamePrefix.Length;
+
+			int end     = hyphen;
 			if (char.IsAsciiDigit (value [end++])) {
 				for ( ; end < value.Length; ++end) {
 					var n = value [end + 1];
@@ -46,7 +49,7 @@ namespace Java.Interop.Tools.Generator
 				}
 			}
 
-			return value.Substring (hyphen + 1, end - hyphen - 1);
+			return value.Substring (hyphen, end - hyphen);
 		}
 
 		// The 'merge.SourceFile' attribute may be on the element, or only on its parent. For example,

--- a/tests/Java.Interop.Tools.Generator-Tests/Utilities/NamingConverterTests.cs
+++ b/tests/Java.Interop.Tools.Generator-Tests/Utilities/NamingConverterTests.cs
@@ -22,6 +22,10 @@ public class NamingConverterTests
 		Assert.AreEqual (28,    v.ApiLevel);
 		Assert.AreEqual (0,     v.MinorRelease);
 
+		v = NamingConverter.ParseApiLevel (@"…\Xamarin-Work\…\bin\BuildDebug\api\api-36.1.xml.in");
+		Assert.AreEqual (36,    v.ApiLevel);
+		Assert.AreEqual (1,     v.MinorRelease);
+
 		v = NamingConverter.ParseApiLevel (@"..\..\bin\BuildDebug\api\api-36.1.xml.in");
 		Assert.AreEqual (36,    v.ApiLevel);
 		Assert.AreEqual (1,     v.MinorRelease);


### PR DESCRIPTION
Context: f07b53855063a297a4b4d3d3b96900dd3729e82c
Context: https://github.com/jpobst/BindingStudio

While using jpobst/BindingStudio to enumify API-36.1, it would crash:

	System.NotSupportedException: Could not parse `W` as an ApiLevel.
	   at Java.Interop.Tools.Generator.AndroidSdkVersion.Parse(String value) in W:\src\jpobst\BindingStudio\external\Java.Interop\src\Java.Interop.Tools.Generator\Utilities\AndroidSdkVersion.cs:line 124
	   at Java.Interop.Tools.Generator.NamingConverter.ParseApiLevel(String value) in W:\src\jpobst\BindingStudio\external\Java.Interop\src\Java.Interop.Tools.Generator\Utilities\NamingConverter.cs:line 21
	   at Java.Interop.Tools.Generator.NamingConverter.ParseApiLevel(XElement element) in W:\src\jpobst\BindingStudio\external\Java.Interop\src\Java.Interop.Tools.Generator\Utilities\NamingConverter.cs:line 60
	   at Java.Interop.Tools.Generator.Enumification.MethodMapEntry.FromElement(XElement element, String parameterName) in W:\src\jpobst\BindingStudio\external\Java.Interop\src\Java.Interop.Tools.Generator\Enumification\MethodMapEntry.cs:line 41
	   at Java.Interop.Tools.Generator.Enumification.MethodMapEntry.FromElement(XElement element, String parameterName) in W:\src\jpobst\BindingStudio\external\Java.Interop\src\Java.Interop.Tools.Generator\Enumification\MethodMapEntry.cs:line 54
	   at Java.Interop.Tools.Generator.Enumification.MethodMapEntry.FromXml(XElement element)+MoveNext() in W:\src\jpobst\BindingStudio\external\Java.Interop\src\Java.Interop.Tools.Generator\Enumification\MethodMapEntry.cs:line 31

The cause of the crash is that the `api-36.1.xml` file it was processing had `//@merge.SourceFile` attributes with the value:

	merge.SourceFile="…Xamarin-Work/src/dotnet/android/build-tools/create-android-api/../../bin/BuildDebug/api/api-36.1.xml.in"

Notice the `-Work` in the value.  This was used by `ExtractApiLevel()` to try to find numbers after the `-`, but `W` was after the `-`, not numbers.

This didn't previously matter because f07b5385 noted:

> *Note*: Changes to `NamingConverter.ParseApiLevel()` are largely a
> nothing-burger because the dotnet/android side usually has metadata:
>
>         <attr
>           api-since="36.1"
>           path="/api//*[contains(@merge.SourceFile,'api-CANARY.xml.in')]"
>           name="api-since">36.1</attr
>
> which explicitly adds/sets `//@api-since` based on the
> `//@merge.SourceFile` value.

However, when jpobst/BindingStudio is used, `src/Mono.Android/metadata` is *not* used, and `//@merge.SourceFile` is instead used.

Improve `ParseApiLevel()` to check for an `api-` prefix before looking for trailing numeric data.